### PR TITLE
fix: two generators of the same type not being rendered

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,25 +5,25 @@
 	"version": "0.2.0",
 	"configurations": [
 		{
+			"type": "node",
+			"name": "vscode-jest-tests.v2",
+			"request": "launch",
+			"program": "${workspaceFolder}/node_modules/.bin/jest",
 			"args": [
-				"--config",
-				"${workspaceFolder}\\.mocharc.json",
-				"-u",
-				"tdd",
-				"--timeout",
-				"999999",
-				"--colors",
-				"${workspaceFolder}/test/**/*.test.ts",
+			  "--runInBand",
+			  "--watchAll=false",
+			  "--testNamePattern",
+			  "${jest.testNamePattern}",
+			  "--runTestsByPath",
+			  "${jest.testFile}"
 			],
 			"cwd": "${workspaceFolder}",
-			"internalConsoleOptions": "openOnSessionStart",
-			"name": "Mocha Tests",
-			"program": "${workspaceFolder}/node_modules/mocha/bin/_mocha",
-			"request": "launch",
-			"skipFiles": [
-				"<node_internals>/**"
-			],
-			"type": "node"
+			"console": "integratedTerminal",
+			"internalConsoleOptions": "neverOpen",
+			"disableOptimisticBPs": true,
+			"windows": {
+			  "program": "${workspaceFolder}/node_modules/jest/bin/jest"
+			}
 		}
 	]
 }

--- a/docs/configurations.md
+++ b/docs/configurations.md
@@ -7,3 +7,10 @@ The only difference between them is what they enable you to do. The difference i
 For example, with the [`custom`](./generators/custom.md) generator, you provide a callback to render something, this is not possible if your configuration file is either `json` or `yaml` format.
 
 Reason those two exist, is because adding a `.js` configuration file to a Java project, might confuse developers, and if you dont need to take advantage of the customization features that require callback, it will probably be better to use one of the other two.
+
+If no explicit configuration file is sat, it will be loaded in the following order:
+- codegen.mjs
+- codegen.js
+- codegen.json
+- codegen.yaml
+- codegen.yml

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,9 +20,9 @@
         "@oclif/plugin-autocomplete": "^3.0.16",
         "@oclif/plugin-help": "^6.0.21",
         "@oclif/plugin-version": "^2.0.17",
+        "cosmiconfig": "^9.0.0",
         "graphology": "^0.25.4",
         "inquirer": "^8.2.6",
-        "supports-esm": "1.0.0",
         "yaml": "^2.4.5",
         "zod": "^3.23.8",
         "zod-validation-error": "^3.3.0"
@@ -1378,7 +1378,6 @@
       "version": "7.24.6",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.24.6.tgz",
       "integrity": "sha512-ZJhac6FkEd1yhG2AHOmfcXG4ceoLltoCVJjN5XsWN9BifBQr+cHJbWi0h68HZuSORq+3WtJ2z0hwF2NG1b5kcA==",
-      "dev": true,
       "dependencies": {
         "@babel/highlight": "^7.24.6",
         "picocolors": "^1.0.0"
@@ -1601,7 +1600,6 @@
       "version": "7.24.6",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.24.6.tgz",
       "integrity": "sha512-4yA7s865JHaqUdRbnaxarZREuPTHrjpDT+pXoAZ1yhyo6uFnIEpS8VMu16siFOHDpZNKYv5BObhsB//ycbICyw==",
-      "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -1634,7 +1632,6 @@
       "version": "7.24.6",
       "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.24.6.tgz",
       "integrity": "sha512-2YnuOp4HAk2BsBrJJvYCbItHx0zWscI1C3zgWkz+wDyD9I7GIVrfnLyrR4Y1VR+7p+chAEcrgRQYZAGIKMV7vQ==",
-      "dev": true,
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.24.6",
         "chalk": "^2.4.2",
@@ -1649,7 +1646,6 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "dev": true,
       "dependencies": {
         "color-convert": "^1.9.0"
       },
@@ -1661,7 +1657,6 @@
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
       "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-      "dev": true,
       "dependencies": {
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
@@ -1675,7 +1670,6 @@
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
       "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dev": true,
       "dependencies": {
         "color-name": "1.1.3"
       }
@@ -1683,14 +1677,12 @@
     "node_modules/@babel/highlight/node_modules/color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-      "dev": true
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
     },
     "node_modules/@babel/highlight/node_modules/escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-      "dev": true,
       "engines": {
         "node": ">=0.8.0"
       }
@@ -1699,7 +1691,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -1708,7 +1699,6 @@
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dev": true,
       "dependencies": {
         "has-flag": "^3.0.0"
       },
@@ -2977,11 +2967,6 @@
       "resolved": "https://registry.npmjs.org/@kwsites/promise-deferred/-/promise-deferred-1.1.1.tgz",
       "integrity": "sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw==",
       "dev": true
-    },
-    "node_modules/@ljharb/has-package-exports-patterns": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/@ljharb/has-package-exports-patterns/-/has-package-exports-patterns-0.0.2.tgz",
-      "integrity": "sha512-4/RWEeXDO6bocPONheFe6gX/oQdP/bEpv0oL4HqjPP5DCenBSt0mHgahppY49N0CpsaqffdwPq+TlX9CYOq2Dw=="
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -6216,7 +6201,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
-      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -6578,6 +6562,31 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
       "dev": true
+    },
+    "node_modules/cosmiconfig": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.0.tgz",
+      "integrity": "sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==",
+      "dependencies": {
+        "env-paths": "^2.2.1",
+        "import-fresh": "^3.3.0",
+        "js-yaml": "^4.1.0",
+        "parse-json": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/d-fischer"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.9.5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
     },
     "node_modules/create-jest": {
       "version": "29.7.0",
@@ -6997,11 +7006,18 @@
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "dev": true
     },
+    "node_modules/env-paths": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/error-ex": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
       "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
-      "dev": true,
       "dependencies": {
         "is-arrayish": "^0.2.1"
       }
@@ -9003,17 +9019,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/has-package-exports": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/has-package-exports/-/has-package-exports-1.3.0.tgz",
-      "integrity": "sha512-e9OeXPQnmPhYoJ63lXC4wWe34TxEGZDZ3OQX9XRqp2VwsfLl3bQBy7VehLnd34g3ef8CmYlBLGqEMKXuz8YazQ==",
-      "dependencies": {
-        "@ljharb/has-package-exports-patterns": "^0.0.2"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/has-property-descriptors": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
@@ -9259,7 +9264,6 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
       "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
-      "dev": true,
       "dependencies": {
         "parent-module": "^1.0.0",
         "resolve-from": "^4.0.0"
@@ -9405,8 +9409,7 @@
     "node_modules/is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
-      "dev": true
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg=="
     },
     "node_modules/is-async-function": {
       "version": "2.0.0",
@@ -10656,8 +10659,7 @@
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "node_modules/js-yaml": {
       "version": "4.1.0",
@@ -10717,9 +10719,7 @@
     "node_modules/json-parse-even-better-errors": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
-      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
-      "dev": true,
-      "peer": true
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="
     },
     "node_modules/json-schema-migrate": {
       "version": "0.2.0",
@@ -10906,9 +10906,7 @@
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
-      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
-      "dev": true,
-      "peer": true
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="
     },
     "node_modules/list-item": {
       "version": "1.1.1",
@@ -12034,7 +12032,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
       "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
-      "dev": true,
       "dependencies": {
         "callsites": "^3.0.0"
       },
@@ -12046,8 +12043,6 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
       "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
-      "dev": true,
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.0.0",
         "error-ex": "^1.3.1",
@@ -12314,8 +12309,7 @@
     "node_modules/picocolors": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.1.tgz",
-      "integrity": "sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew==",
-      "dev": true
+      "integrity": "sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew=="
     },
     "node_modules/picomatch": {
       "version": "2.3.1",
@@ -12880,7 +12874,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
       "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
-      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -13740,14 +13733,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/supports-color?sponsor=1"
-      }
-    },
-    "node_modules/supports-esm": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/supports-esm/-/supports-esm-1.0.0.tgz",
-      "integrity": "sha512-96Am8CDqUaC0I2+C/swJ0yEvM8ZnGn4unoers/LSdE4umhX7mELzqyLzx3HnZAluq5PXIsGMKqa7NkqaeHMPcg==",
-      "dependencies": {
-        "has-package-exports": "^1.1.0"
       }
     },
     "node_modules/supports-hyperlinks": {

--- a/package.json
+++ b/package.json
@@ -18,9 +18,9 @@
     "@oclif/plugin-autocomplete": "^3.0.16",
     "@oclif/plugin-help": "^6.0.21",
     "@oclif/plugin-version": "^2.0.17",
+    "cosmiconfig": "^9.0.0",
     "graphology": "^0.25.4",
     "inquirer": "^8.2.6",
-    "supports-esm": "1.0.0",
     "yaml": "^2.4.5",
     "zod": "^3.23.8",
     "zod-validation-error": "^3.3.0"

--- a/src/codegen/configuration-manager.ts
+++ b/src/codegen/configuration-manager.ts
@@ -9,7 +9,19 @@ import {fromError} from 'zod-validation-error';
 import {includeTypeScriptChannelDependencies} from './generators/typescript/channels';
 import { DeepPartial, mergePartialAndDefault } from './utils';
 import { cosmiconfig } from 'cosmiconfig';
-const explorer = cosmiconfig('codegen');
+const moduleName = 'codegen';
+const explorer = cosmiconfig(moduleName, {
+  searchPlaces: [
+  `${moduleName}.json`,
+  `${moduleName}.yaml`,
+  `${moduleName}.yml`,
+  `${moduleName}.js`,
+  `${moduleName}.ts`,
+  `${moduleName}.mjs`,
+  `${moduleName}.cjs`,
+  ],
+  mergeSearchPlaces: true
+});
 
 export async function loadConfigFile(
   filePath?: string
@@ -24,9 +36,12 @@ export async function loadConfigFile(
     cosmiConfig = await explorer.search();
   }
   let codegenConfig;
+  if (!cosmiConfig) {
+    throw new Error('Cannot find configuration...');
+  }
   if (typeof cosmiConfig.config.default === 'function') {
     codegenConfig = cosmiConfig.config.default();
-  } else if (cosmiConfig.config.default) {
+  } else if (typeof cosmiConfig.config.default === 'object') {
     codegenConfig = cosmiConfig.config.default;
   } else {
     codegenConfig = cosmiConfig.config;

--- a/src/codegen/configuration-manager.ts
+++ b/src/codegen/configuration-manager.ts
@@ -1,76 +1,41 @@
 import {
   TheCodegenConfiguration,
-  LoadArgument,
   zodTheCodegenConfiguration,
   Generators
 } from './types';
 import {getDefaultConfiguration} from './generators/index';
-import path from 'node:path';
-import yaml from 'yaml';
-import fs from 'fs';
 import {Logger} from '../LoggingInterface';
 import {fromError} from 'zod-validation-error';
 import {includeTypeScriptChannelDependencies} from './generators/typescript/channels';
-import { DeepPartial, getOSType, mergePartialAndDefault } from './utils';
-import { cwd } from 'process';
-// eslint-disable-next-line @typescript-eslint/no-var-requires, no-undef
-const supportsESM = require('supports-esm');
+import { DeepPartial, mergePartialAndDefault } from './utils';
+import { cosmiconfig } from 'cosmiconfig';
+const explorer = cosmiconfig('codegen');
 
 export async function loadConfigFile(
-  loadArguments: LoadArgument
-): Promise<TheCodegenConfiguration> {
-  const {configType} = loadArguments;
-  if (configType === 'esm') {
-    return loadEsmConfig(loadArguments);
-  } else if (configType === 'json') {
-    return loadJsonConfig(loadArguments);
-  } else if (configType === 'yaml') {
-    return loadYamlConfig(loadArguments);
+  filePath?: string
+): Promise<{
+  config: TheCodegenConfiguration,
+  filePath: string
+}> {
+  let cosmiConfig: any;
+  if (filePath) {
+    cosmiConfig = await explorer.load(filePath);
+  } else {
+    cosmiConfig = await explorer.search();
   }
-  throw new Error('Load configuration not found');
-}
-
-async function loadJsonConfig({
-  configPath
-}: LoadArgument): Promise<TheCodegenConfiguration> {
-  const stringConfigFile = await fs.promises.readFile(configPath, 'utf8');
-  if (stringConfigFile) {
-    const config = JSON.parse(stringConfigFile);
-    return realizeConfiguration(config);
+  let codegenConfig;
+  if (typeof cosmiConfig.config.default === 'function') {
+    codegenConfig = cosmiConfig.config.default();
+  } else if (cosmiConfig.config.default) {
+    codegenConfig = cosmiConfig.config.default;
+  } else {
+    codegenConfig = cosmiConfig.config;
   }
-
-  throw new Error('Could not load JSON configuration file, nothing to read');
-}
-
-async function loadYamlConfig({
-  configPath
-}: LoadArgument): Promise<TheCodegenConfiguration> {
-  const stringConfigFile = await fs.promises.readFile(configPath, 'utf8');
-  if (stringConfigFile) {
-    const config = yaml.parse(stringConfigFile);
-    return realizeConfiguration(config);
-  }
-
-  throw new Error('Could not load YAML configuration file, nothing to read');
-}
-
-async function loadEsmConfig({
-  configPath
-}: LoadArgument): Promise<TheCodegenConfiguration> {
-  if (supportsESM) {
-    if (getOSType() === 'windows' && configPath.slice(0, 6) !== 'file://') {
-      // Windows MUST be valid absolute paths file:// URLs before importing it.
-      configPath = `file://${configPath}`;
-    }
-    const esmConfigFile = await import(`${configPath}`);
-    if (esmConfigFile.default) {
-      return realizeConfiguration(esmConfigFile.default);
-    }
-
-    throw new Error('Remember to export with `default`');
-  }
-
-  throw new Error('Cannot load ESM in the current setup');
+  const realizedConfiguration = realizeConfiguration(codegenConfig);
+  return {
+    config: realizedConfiguration,
+    filePath: cosmiConfig.filepath
+  };
 }
 
 /**
@@ -140,54 +105,4 @@ function ensureProperGenerators(config: TheCodegenConfiguration) {
     }
   }
   return newGenerators;
-}
-
-async function checkFileExists(configFileLoad: LoadArgument) {
-  const {configPath, configType} = configFileLoad;
-  const filePath = path.resolve(cwd(), configPath);
-  try {
-    await fs.promises.access(filePath, fs.constants.F_OK);
-    return {exists: true, configPath: filePath, configType};
-  } catch {
-    return {exists: false, configPath: filePath, configType};
-  }
-}
-
-export async function discoverConfiguration(
-  filePath?: string
-): Promise<LoadArgument> {
-  if (filePath) {
-    let fullConfigPath = filePath;
-    if (!path.isAbsolute(filePath)) {
-      fullConfigPath = path.resolve(cwd(), filePath);
-    }
-    const extension = path.extname(fullConfigPath);
-    if (extension === '.json') {
-      return {configPath: fullConfigPath, configType: 'json'};
-    } else if (extension === '.yaml' || extension === '.yml') {
-      return {configPath: fullConfigPath, configType: 'yaml'};
-    } else if (extension === '.mjs' || extension === '.js') {
-      return {configPath: fullConfigPath, configType: 'esm'};
-    }
-    Logger.warn(
-      `Could figure out the right configuration format, trying to use esm configuration for ${fullConfigPath}, which had extension ${extension}`
-    );
-    return {configPath: fullConfigPath, configType: 'esm'};
-  }
-  const result = (
-    await Promise.all([
-      checkFileExists({configPath: 'codegen.mjs', configType: 'esm'}),
-      checkFileExists({configPath: 'codegen.js', configType: 'esm'}),
-      checkFileExists({configPath: 'codegen.json', configType: 'json'}),
-      checkFileExists({configPath: 'codegen.yaml', configType: 'yaml'}),
-      checkFileExists({configPath: 'codegen.yml', configType: 'yaml'})
-    ])
-  ).find((entry) => entry.exists === true);
-  if (result === undefined) {
-    throw new Error(
-      'Could not find configurations on default paths, please provide one'
-    );
-  } else {
-    return result;
-  }
 }

--- a/src/codegen/generators/generic/custom.ts
+++ b/src/codegen/generators/generic/custom.ts
@@ -18,6 +18,7 @@ export const zodCustomGenerator = z.object({
   id: z.string().optional(),
   dependencies: z.array(z.string()).optional(),
   preset: z.literal('custom'),
+  options: z.any().optional(),
   renderFunction: z
     .function()
     .args(
@@ -25,10 +26,10 @@ export const zodCustomGenerator = z.object({
         inputType: z.enum(['asyncapi']),
         generator: z.any(),
         options: z.any()
-      }),
-      z.any()
+      }).optional(),
+      z.any().optional()
     )
-    .returns(z.boolean())
+    .returns(z.any())
 });
 
 export const defaultCustomGenerator: CustomGenerator = {

--- a/src/codegen/generators/index.ts
+++ b/src/codegen/generators/index.ts
@@ -24,7 +24,7 @@ import {
   defaultTypeScriptChannelsGenerator
 } from './typescript';
 import {defaultCustomGenerator} from './generic/custom';
-import {CsharpPayloadGenerator, generateCsharpPayload} from './csharp';
+import {CsharpPayloadGenerator, generateCsharpPayload, defaultCsharpPayloadGenerator} from './csharp';
 
 export {
   TypeScriptChannelsGenerator,
@@ -35,7 +35,10 @@ export {
   defaultTypeScriptPayloadGenerator,
   TypescriptParametersGenerator,
   generateTypescriptParameters,
-  defaultTypeScriptParametersOptions
+  defaultTypeScriptParametersOptions,
+  CsharpPayloadGenerator,
+  generateCsharpPayload,
+  defaultCsharpPayloadGenerator
 };
 
 export {JavaPayloadGenerator, generateJavaPayload, defaultJavaPayloadGenerator};
@@ -174,6 +177,8 @@ export function getDefaultConfiguration(
           return defaultTypeScriptPayloadGenerator;
         case 'java':
           return defaultJavaPayloadGenerator;
+        case 'csharp':
+          return defaultCsharpPayloadGenerator;
         default:
           return undefined;
       }

--- a/src/codegen/generators/typescript/channels/index.ts
+++ b/src/codegen/generators/typescript/channels/index.ts
@@ -18,6 +18,7 @@ import {z} from 'zod';
 import {renderCorePublish} from './protocols/nats/corePublish';
 import {renderCoreSubscribe} from './protocols/nats/coreSubscribe';
 import {renderJetstreamPushSubscription} from './protocols/nats/jetstreamPushSubscription';
+import { ensureRelativePath } from '../../../utils';
 export type SupportedProtocols = 'nats';
 
 export const zodTypescriptChannelsGenerator = z.object({
@@ -103,7 +104,7 @@ export async function generateTypeScriptChannels(
     );
 
     dependencies.push(
-      `import {${parameter.modelName}} from '${parameterImportPath}';`
+      `import {${parameter.modelName}} from '${ensureRelativePath(parameterImportPath)}';`
     );
     const payload = payloads.channelModels[channel.id()] as OutputModel;
     if (payload === undefined) {
@@ -117,7 +118,7 @@ export async function generateTypeScriptChannels(
       path.resolve(payloadGenerator.outputPath, payload.modelName)
     );
     dependencies.push(
-      `import {${payload.modelName}} from '${payloadImportPath}';`
+      `import {${payload.modelName}} from '${ensureRelativePath(payloadImportPath)}';`
     );
 
     for (const protocol of protocolsToUse) {
@@ -140,10 +141,9 @@ export async function generateTypeScriptChannels(
             renderCoreSubscribe(natsContext)
           ];
           codeToRender.push(...renders.map((value) => value.code));
-          const deps = renders
-            .map((value) => value.dependencies)
-            .flat(Infinity);
-          dependencies.push(...(new Set(deps) as any));
+          const renderedDependencies = renders
+            .map((value) => value.dependencies).flat(Infinity);
+          dependencies.push(...(new Set(renderedDependencies) as any));
           break;
         }
 

--- a/src/codegen/generators/typescript/parameters.ts
+++ b/src/codegen/generators/typescript/parameters.ts
@@ -3,7 +3,6 @@ import {
   TS_DESCRIPTION_PRESET,
   TypeScriptFileGenerator
 } from '@asyncapi/modelina';
-import {Logger} from '../../../LoggingInterface';
 import {AsyncAPIDocumentInterface} from '@asyncapi/parser';
 import {GenericCodegenContext, ParameterRenderType} from '../../types';
 import {z} from 'zod';
@@ -79,7 +78,6 @@ public getChannelWithParameters(channel: string) {
         schemaObj.properties[parameter.id()] = parameter.schema()?.json();
         schemaObj.required.push(parameter.id());
       }
-      Logger.info(schemaObj);
       const models = await modelinaGenerator.generateToFiles(
         schemaObj,
         generator.outputPath,

--- a/src/codegen/render-graph.ts
+++ b/src/codegen/render-graph.ts
@@ -55,7 +55,7 @@ export async function renderGraph(
     const alreadyRenderedNodes = Object.keys(renderedContext);
     for (const nodeEntry of nodesToRender) {
       const dependencies = graph.inEdgeEntries(nodeEntry.node);
-      //check if all dependencies have been rendered
+      //check if all dependencies have been rendered, if not, wait until later
       let allRendered = true;
       for (const dependency of dependencies) {
         if (!alreadyRenderedNodes.includes(dependency.source)) {

--- a/src/codegen/render-graph.ts
+++ b/src/codegen/render-graph.ts
@@ -1,6 +1,7 @@
 import {renderGenerator} from './generators';
 import {Generators, RunGeneratorContext} from './types';
 import Graph from 'graphology';
+import { findDuplicatesInArray } from './utils';
 
 export type Node = {
   generator: Generators;
@@ -9,6 +10,11 @@ type GraphType = Graph<Node>;
 
 export function determineRenderGraph(context: RunGeneratorContext): GraphType {
   const {configuration} = context;
+  const duplicateGenerators = findDuplicatesInArray(context.configuration.generators, 'id');
+  if (duplicateGenerators.length > 0) {
+    throw new Error(`There are two or more generators that use the same id, please use unique id's for each generator, id('s) are ${duplicateGenerators.join(', ')}`);
+  }
+
   const graph = new Graph<Node>({allowSelfLoops: true, type: 'directed'});
   for (const generator of configuration.generators as Generators[]) {
     graph.addNode(generator.id, {generator});

--- a/src/codegen/utils.ts
+++ b/src/codegen/utils.ts
@@ -60,3 +60,14 @@ export function mergePartialAndDefault<T extends Record<string, any>>(
 
   return target as T;
 }
+
+/**
+ * Find duplicates in array of objects based on property
+ */
+export function findDuplicatesInArray(array: any[], property: string) {
+  const foundValues = array.map((generator) => {
+    return generator[property];
+  });
+  const duplicates = foundValues.filter((item, index) => foundValues.indexOf(item) !== index);
+  return Array.from(new Set(duplicates));
+}

--- a/src/codegen/utils.ts
+++ b/src/codegen/utils.ts
@@ -1,6 +1,8 @@
 /* eslint-disable @typescript-eslint/ban-types */
 /* eslint-disable security/detect-object-injection */
 
+import { platform } from 'process';
+
 /**
  * Deep partial type that does NOT partial function arguments.
  */
@@ -50,7 +52,7 @@ export function mergePartialAndDefault<T extends Record<string, any>>(
     const isArray = Array.isArray(prop);
     if (isArray) {
       // merge array into target with a new array instance so we dont touch the default value
-      target[propName] = [...(target[propName] ?? []), ...(prop ?? [])];
+      target[propName] = ensureUniqueValuesInArray([...(target[propName] ?? []), ...(prop ?? [])]);
     } else if (isObjectOrClass && isRegularObject) {
       target[propName] = mergePartialAndDefault(target[propName], prop);
     } else if (prop) {
@@ -70,4 +72,32 @@ export function findDuplicatesInArray(array: any[], property: string) {
   });
   const duplicates = foundValues.filter((item, index) => foundValues.indexOf(item) !== index);
   return Array.from(new Set(duplicates));
+}
+
+/**
+ * Get OS type, abstracted away from special cases
+ */
+export function getOSType(): 'windows' | 'unix' | 'macos' {
+  if (platform === 'win32') {return 'windows';}
+  if (platform === 'darwin') {return 'macos';}
+  return 'unix';
+}
+
+/**
+ * Windows renders relative paths weird i.e. '\' instead of '/'
+ */
+export function ensureRelativePath(pathToCheck: string) {
+  if (getOSType() === 'windows') {
+    return pathToCheck.replaceAll('\\', '/');
+  }
+  return pathToCheck;
+}
+
+/**
+ * Ensure array has unique values only.
+ */
+export function ensureUniqueValuesInArray(array: any[]) {
+  return array.filter((value, index, filteredArray) => {
+    return filteredArray.indexOf(value) === index;
+  });
 }

--- a/src/commands/generate.ts
+++ b/src/commands/generate.ts
@@ -1,7 +1,6 @@
 import {Args, Command, Flags} from '@oclif/core';
 import path from 'node:path';
 import {
-  discoverConfiguration,
   loadConfigFile
 } from '../codegen/configuration-manager';
 import {Logger} from '../LoggingInterface';
@@ -40,23 +39,20 @@ export default class Generate extends Command {
     });
     const {file} = args;
     // eslint-disable-next-line no-undef
-    const configurationArgument = await discoverConfiguration(file);
-    Logger.info(`Found config file at ${configurationArgument.configPath}`);
-    const configuration = await loadConfigFile(configurationArgument);
-    Logger.info(`Found configuration was ${JSON.stringify(configuration)}`);
-
+    const {config, filePath} = await loadConfigFile(file);
+    Logger.info(`Found configuration was ${JSON.stringify(config)}`);
     const documentPath = path.resolve(
-      path.dirname(configurationArgument.configPath),
-      configuration.inputPath
+      path.dirname(filePath),
+      config.inputPath
     );
     Logger.info(`Found document at '${documentPath}'`);
-    Logger.info(`Found input '${configuration.inputType}'`);
+    Logger.info(`Found input '${config.inputType}'`);
     const context: RunGeneratorContext = {
-      configuration,
+      configuration: config,
       documentPath,
-      configFilePath: configurationArgument.configPath
+      configFilePath: filePath
     };
-    if (configuration.inputType === 'asyncapi') {
+    if (config.inputType === 'asyncapi') {
       const document = await loadAsyncapi(context);
       context.asyncapiDocument = document;
     }

--- a/test/codegen/configuration-manager.spec.ts
+++ b/test/codegen/configuration-manager.spec.ts
@@ -6,7 +6,6 @@ const CONFIG_JSON = path.resolve(__dirname, '../configs/config.json');
 const CONFIG_YAML = path.resolve(__dirname, '../configs/config.yaml');
 const FULL_CONFIG = path.resolve(__dirname, '../configs/config-all.js');
 import {discoverConfiguration, loadConfigFile, realizeConfiguration} from '../../src/codegen/configuration-manager.ts';
-import { TheCodegenConfiguration } from '../../src/codegen/types.ts';
 import { Logger } from '../../src/LoggingInterface.ts';
 
 describe('configuration manager', () => {
@@ -43,10 +42,9 @@ describe('configuration manager', () => {
     const loadedConfig = await loadConfigFile(config);
     expect(loadedConfig.inputType).toEqual('asyncapi');
   });
-  
   describe('realizeConfiguration', () => {
     it('should be able to validate correct configuration', async () => {
-      const configuration: TheCodegenConfiguration = {
+      const configuration: any = {
         inputType: "asyncapi",
         inputPath: "asyncapi.json",
         language: "typescript",
@@ -60,6 +58,58 @@ describe('configuration manager', () => {
       };    
       const realizedConfiguration = realizeConfiguration(configuration);
       expect(realizedConfiguration.generators.length).toEqual(3);
+    });
+    
+    it('should handle duplicate generators with no id', async () => {
+      const configuration: any = {
+        inputType: "asyncapi",
+        inputPath: "asyncapi.json",
+        language: "typescript",
+        generators: [
+          {
+            preset: 'payloads',
+            outputPath: './src/__gen__/payload',
+            serializationType: 'json',
+          },
+          {
+            preset: 'payloads',
+            outputPath: './src/__gen__/payload',
+            serializationType: 'json',
+          }
+        ]
+      };    
+      const realizedConfiguration = realizeConfiguration(configuration);
+      expect(realizedConfiguration.generators[0].id).toEqual('payloads-typescript');
+      expect(realizedConfiguration.generators[1].id).toEqual('payloads-typescript-1');
+    });
+
+    it('should handle multiple duplicate generators with no id', async () => {
+      const configuration: any = {
+        inputType: "asyncapi",
+        inputPath: "asyncapi.json",
+        language: "typescript",
+        generators: [
+          {
+            preset: 'payloads',
+            outputPath: './src/__gen__/payload',
+            serializationType: 'json',
+          },
+          {
+            preset: 'payloads',
+            outputPath: './src/__gen__/payload',
+            serializationType: 'json',
+          },
+          {
+            preset: 'payloads',
+            outputPath: './src/__gen__/payload',
+            serializationType: 'json',
+          }
+        ]
+      };    
+      const realizedConfiguration = realizeConfiguration(configuration);
+      expect(realizedConfiguration.generators[0].id).toEqual('payloads-typescript');
+      expect(realizedConfiguration.generators[1].id).toEqual('payloads-typescript-1');
+      expect(realizedConfiguration.generators[2].id).toEqual('payloads-typescript-2');
     });
 
     it('should give errors on incorrect data', async () => {

--- a/test/codegen/configuration-manager.spec.ts
+++ b/test/codegen/configuration-manager.spec.ts
@@ -5,42 +5,31 @@ const CONFIG_MJS = path.resolve(__dirname, '../configs/config.js');
 const CONFIG_JSON = path.resolve(__dirname, '../configs/config.json');
 const CONFIG_YAML = path.resolve(__dirname, '../configs/config.yaml');
 const FULL_CONFIG = path.resolve(__dirname, '../configs/config-all.js');
-import {discoverConfiguration, loadConfigFile, realizeConfiguration} from '../../src/codegen/configuration-manager.ts';
+import {loadConfigFile, realizeConfiguration} from '../../src/codegen/configuration-manager.ts';
 import { Logger } from '../../src/LoggingInterface.ts';
 
 describe('configuration manager', () => {
-  it('should work with correct ESM config', async () => {
-    const config = await loadConfigFile({
-      configPath: CONFIG_MJS,
-      configType: 'esm'
+  describe('loadConfigFile', () => {
+    it('should work with correct ESM config', async () => {
+      const {config} = await loadConfigFile(CONFIG_MJS);
+      expect(config.inputType).toEqual('asyncapi');
     });
-    expect(config.inputType).toEqual('asyncapi');
-  });
-  it('should work with correct JSON config', async () => {
-    const config = await loadConfigFile({
-      configPath: CONFIG_JSON,
-      configType: 'json'
+    it('should work with correct JSON config', async () => {
+      const {config} = await loadConfigFile(CONFIG_JSON);
+      expect(config.inputType).toEqual('asyncapi');
     });
-    expect(config.inputType).toEqual('asyncapi');
-  });
-  it('should work with correct YAML config', async () => {
-    const config = await loadConfigFile({
-      configPath: CONFIG_YAML,
-      configType: 'yaml'
+    it('should work with correct YAML config', async () => {
+      const {config} = await loadConfigFile(CONFIG_YAML);
+      expect(config.inputType).toEqual('asyncapi');
     });
-    expect(config.inputType).toEqual('asyncapi');
-  });
-  it('should work with full configuration', async () => {
-    const config = await loadConfigFile({
-      configPath: FULL_CONFIG,
-      configType: 'esm'
+    it('should work with full configuration', async () => {
+      const {config} = await loadConfigFile(FULL_CONFIG);
+      expect(config.inputType).toEqual('asyncapi');
     });
-    expect(config.inputType).toEqual('asyncapi');
-  });
-  it('should work with discover configuration', async () => {
-    const config = await discoverConfiguration(CONFIG_JSON);
-    const loadedConfig = await loadConfigFile(config);
-    expect(loadedConfig.inputType).toEqual('asyncapi');
+    it('should work with discover configuration', async () => {
+      const {config} = await loadConfigFile(CONFIG_JSON);
+      expect(config.inputType).toEqual('asyncapi');
+    });
   });
   describe('realizeConfiguration', () => {
     it('should be able to validate correct configuration', async () => {

--- a/test/codegen/render-graph.spec.ts
+++ b/test/codegen/render-graph.spec.ts
@@ -11,7 +11,7 @@ jest.mock('../../src/codegen/generators', () => {
 
 describe('Render graph', () => {
   it('should correctly determine render graph for all generators', async () => {
-    const context: RunGeneratorContext = {
+    const context: any = {
       configuration: {
         inputType: 'asyncapi',
         inputPath: "asyncapi.json",
@@ -21,7 +21,7 @@ describe('Render graph', () => {
             outputPath: './src/__gen__/payload',
             serializationType: 'json',
             id: 'payloads-typescript',
-            language: 'typescript'
+            language: 'typescript',
           },
           {
             preset: 'payloads',
@@ -66,6 +66,7 @@ describe('Render graph', () => {
     await renderGraph(context, graph);
     expect(renderGeneratorSpy).toHaveBeenCalledTimes(context.configuration.generators.length);
   });
+  
   it('should throw error on circular graphs', async () => {
     const context: RunGeneratorContext = {
       configuration: {
@@ -123,5 +124,36 @@ describe('Render graph', () => {
     const renderGeneratorSpy = jest.spyOn(generators, "renderGenerator");
     renderGeneratorSpy.mockResolvedValue(undefined);
     expect(() => determineRenderGraph(context)).toThrow("You are not allowed to have self dependant generators");
+  });
+  it('should throw error when two generators has the same id', async () => {
+    const context: any = {
+      configuration: {
+        inputType: 'asyncapi',
+        inputPath: "asyncapi.json",
+        generators: [
+          {
+            preset: 'payloads',
+            outputPath: './src/__gen__/payload',
+            serializationType: 'json',
+            id: 'payloads-typescript',
+            language: 'typescript',
+          },
+          {
+            preset: 'payloads',
+            outputPath: './src/__gen__/payload',
+            serializationType: 'json',
+            id: 'payloads-typescript',
+            language: 'typescript',
+          }
+        ]
+      }, 
+      documentPath: 'test',
+      configFilePath: '',
+      asyncapiDocument: undefined
+    };
+
+    const renderGeneratorSpy = jest.spyOn(generators, "renderGenerator");
+    renderGeneratorSpy.mockResolvedValue(undefined);
+    expect(() => determineRenderGraph(context)).toThrow('There are two or more generators that use the same id, please use unique id\'s for each generator, id(\'s) are payloads-typescript');
   });
 });

--- a/test/runtime/typescript/codegen.mjs
+++ b/test/runtime/typescript/codegen.mjs
@@ -1,4 +1,4 @@
-/** @type {import("@the-codegen-project/cli").TheCodegenConfiguration} **/
+/** @type {import("../../../").TheCodegenConfiguration} **/
 export default {
 	inputType: 'asyncapi',
 	inputPath: '../asyncapi.json',

--- a/test/runtime/typescript/package.json
+++ b/test/runtime/typescript/package.json
@@ -1,7 +1,7 @@
 {
   "scripts": {
     "test": "jest",
-    "generate": "codegen generate"
+    "generate": "node ../../../bin/run.mjs generate"
   },
   "dependencies": {
     "@swc/core": "^1.3.5",


### PR DESCRIPTION
Fixes https://github.com/the-codegen-project/cli/issues/66
Fixes custom generator not handling options correctly
Cli now throws error if two or more generators use the same explicit id
Fixes windows cant load configuration file
Fixes CLI not working with absolute paths
Fixes on windows it generates incorrect import statements for typescript channels generator
Fixes C# payload generator not exported
Add additional configuration locations