### PR TITLE
fix: enum type support

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -3,4 +3,5 @@ examples
 test/runtime
 dist
 tmp
+playground/**/*
 jest.config.js

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ oclif.manifest.json
 dist
 coverage
 test/config/src/__gen__/
+playground/__gen__

--- a/.prettierc.mjs
+++ b/.prettierc.mjs
@@ -2,8 +2,8 @@ import companyPrettierConfig from "@oclif/prettier-config";
 
 export default {
   ...companyPrettierConfig,
-  "semi": true,
-  "trailingComma": "none",
-  "singleQuote": true,
-  "printWidth": 80
+  semi: true,
+  trailingComma: "none",
+  singleQuote: true,
+  printWidth: 80,
 };

--- a/.prettierc.mjs
+++ b/.prettierc.mjs
@@ -1,9 +1,0 @@
-import companyPrettierConfig from "@oclif/prettier-config";
-
-export default {
-  ...companyPrettierConfig,
-  semi: true,
-  trailingComma: "none",
-  singleQuote: true,
-  printWidth: 80,
-};

--- a/.prettierrc.mjs
+++ b/.prettierrc.mjs
@@ -1,0 +1,9 @@
+import companyPrettierConfig from '@oclif/prettier-config';
+
+export default {
+  ...companyPrettierConfig,
+  semi: true,
+  trailingComma: 'none',
+  singleQuote: true,
+  printWidth: 80
+};

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "generate:readme:toc": "markdown-toc -i README.md && markdown-toc -i ./docs/usage.md && markdown-toc -i ./docs/README.md",
     "lint": "eslint --max-warnings 0 --config .eslintrc .",
     "lint:fix": "npm run lint -- --fix",
-    "format": "prettier --config .prettierc.mjs \"./src/**/*.ts\" --write",
+    "format": "prettier --config .prettierrc.mjs \"./src/**/*.ts\" --write",
     "pack:all": "npm run pack:macos && npm run pack:linux && npm run pack:tarballs && npm run pack:windows",
     "pack:macos": "oclif pack macos && npm run pack:rename",
     "pack:linux": "oclif pack deb && npm run pack:rename",

--- a/playground/codegen.ts
+++ b/playground/codegen.ts
@@ -1,0 +1,30 @@
+import { TheCodegenConfiguration } from "@the-codegen-project/cli";
+const config: TheCodegenConfiguration = {
+  inputType: "asyncapi",
+  inputPath: "./schema.json",
+  language: "typescript",
+  generators: [
+    {
+      preset: "channels",
+      outputPath: "./__gen__/channels",
+      protocols: ["nats"],
+    },
+    {
+      preset: "payloads",
+      outputPath: "./__gen__/payloads",
+      serializationType: "json",
+      model: "class",
+      enum: "enum",
+      map: "record",
+      moduleSystem: "esm",
+      useForJavaScript: true,
+      rawPropertyNames: false,
+    },
+    {
+      preset: "parameters",
+      outputPath: "./__gen__/parameters",
+      serializationType: "json",
+    },
+  ],
+};
+export default config;

--- a/playground/schema.json
+++ b/playground/schema.json
@@ -1,0 +1,398 @@
+{
+  "asyncapi": "2.0.0",
+  "info": {
+    "title": "Blackbox API",
+    "version": "0.1.0",
+    "description": "This service is in charge of handling the code gen flow"
+  },
+  "defaultContentType": "application/json",
+  "servers": {
+    "local": {
+      "url": "localhost:4672",
+      "protocol": "nats",
+      "description": "Local test broker"
+    }
+  },
+  "channels": {
+    "runs.command.start.{type}.{run_uid}": {
+      "description": "This starts a run",
+      "parameters": {
+        "run_uid": { "schema": { "type": "string" } },
+        "type": {
+          "schema": { "type": "string", "enum": ["openapi", "asyncapi"] }
+        }
+      },
+      "subscribe": {
+        "summary": "Start a run",
+        "operationId": "startRun",
+        "message": { "$ref": "#/components/messages/startRun" }
+      },
+      "bindings": { "nats": { "x-jetstream": { "name": "StartRun" } } }
+    },
+    "runs.command.forceGeneration": {
+      "description": "This force a generation with very basic information as the rest is fetched",
+      "publish": {
+        "summary": "Force a generation with specific information",
+        "operationId": "forceGeneration",
+        "message": { "$ref": "#/components/messages/forceGeneration" }
+      },
+      "bindings": { "nats": { "x-jetstream": { "name": "ForceGeneration" } } }
+    },
+    "runs.checked.{check_id}": {
+      "description": "Checked a for changes and potentially created some runs",
+      "parameters": { "check_id": { "schema": { "type": "string" } } },
+      "subscribe": {
+        "operationId": "checkedForChanges",
+        "message": { "$ref": "#/components/messages/checkedForChanges" }
+      },
+      "bindings": { "nats": { "x-jetstream": { "name": "CheckedForChange" } } }
+    },
+    "runs.command.check.project.{project_id}": {
+      "description": "This check a project to see if anything needs to be generated",
+      "parameters": { "project_id": { "schema": { "type": "string" } } },
+      "publish": {
+        "operationId": "checkProject",
+        "message": { "$ref": "#/components/messages/checkProject" }
+      },
+      "bindings": {
+        "nats": {
+          "x-jetstream": {
+            "name": "CheckProject",
+            "subjects": ["runs.command.check.project.>"]
+          }
+        }
+      }
+    },
+    "runs.command.check.project.{project_id}.document_instance.{document_instance_id}": {
+      "description": "This check a document instance to see if any of the generators needs to have something generated",
+      "parameters": {
+        "project_id": { "schema": { "type": "string" } },
+        "document_instance_id": { "schema": { "type": "string" } }
+      },
+      "publish": {
+        "operationId": "checkDocumentInstance",
+        "message": { "$ref": "#/components/messages/checkDocumentInstance" }
+      },
+      "bindings": {
+        "$ref": "#/channels/runs.command.check.project.%7Bproject_id%7D/bindings"
+      }
+    },
+    "runs.command.check.project.{project_id}.document_instance.{document_instance_id}.generator.{generator_id}": {
+      "description": "This check a generator whether we need to update anything",
+      "parameters": {
+        "project_id": { "schema": { "type": "string" } },
+        "document_instance_id": { "schema": { "type": "string" } },
+        "generator_id": { "schema": { "type": "string" } }
+      },
+      "publish": {
+        "operationId": "checkGenerator",
+        "message": { "$ref": "#/components/messages/checkGenerator" }
+      },
+      "bindings": {
+        "$ref": "#/channels/runs.command.check.project.%7Bproject_id%7D/bindings"
+      }
+    },
+    "runs.status.{run_uid}.log": {
+      "description": "Used to log different kind of information for a run",
+      "parameters": { "run_uid": { "schema": { "type": "string" } } },
+      "subscribe": {
+        "operationId": "logRun",
+        "message": { "$ref": "#/components/messages/logRun" }
+      },
+      "bindings": { "nats": { "x-jetstream": { "name": "LogRun" } } }
+    },
+    "runs.status.{run_uid}.done": {
+      "description": "Used when the run is completed successfully",
+      "parameters": { "run_uid": { "schema": { "type": "string" } } },
+      "subscribe": {
+        "operationId": "runDone",
+        "message": { "$ref": "#/components/messages/runDone" }
+      },
+      "bindings": { "nats": { "x-jetstream": { "name": "RunDone" } } }
+    },
+    "runs.status.{run_uid}.stopped": {
+      "description": "Used when the run stopped unexpected",
+      "parameters": { "run_uid": { "schema": { "type": "string" } } },
+      "subscribe": {
+        "operationId": "runStopped",
+        "message": { "$ref": "#/components/messages/runStopped" }
+      },
+      "bindings": { "nats": { "x-jetstream": { "name": "RunStopped" } } }
+    }
+  },
+  "components": {
+    "messages": {
+      "startRun": {
+        "name": "startRun",
+        "title": "Start run",
+        "schemaFormat": "application/schema+json;version=draft-07",
+        "payload": { "$ref": "#/components/schemas/startRun" }
+      },
+      "forceGeneration": {
+        "name": "forceGeneration",
+        "title": "Force start a run",
+        "schemaFormat": "application/schema+json;version=draft-07",
+        "payload": { "$ref": "#/components/schemas/forceGeneration" }
+      },
+      "checkedForChanges": {
+        "name": "checkedForChanges",
+        "schemaFormat": "application/schema+json;version=draft-07",
+        "payload": { "$ref": "#/components/schemas/checkedForChanges" }
+      },
+      "checkProject": {
+        "name": "checkProject",
+        "schemaFormat": "application/schema+json;version=draft-07",
+        "payload": { "$ref": "#/components/schemas/runCheck" }
+      },
+      "checkDocumentInstance": {
+        "name": "checkDocumentInstance",
+        "schemaFormat": "application/schema+json;version=draft-07",
+        "payload": { "$ref": "#/components/schemas/runCheck" }
+      },
+      "checkGenerator": {
+        "name": "checkGenerator",
+        "schemaFormat": "application/schema+json;version=draft-07",
+        "payload": { "$ref": "#/components/schemas/runCheck" }
+      },
+      "logRun": {
+        "name": "logRun",
+        "title": "Log something for the run",
+        "payload": { "$ref": "#/components/schemas/logRun" }
+      },
+      "runStopped": {
+        "name": "runStopped",
+        "title": "Run has been stopped run",
+        "payload": { "$ref": "#/components/schemas/runStopped" }
+      },
+      "runDone": {
+        "name": "runDone",
+        "title": "Run is done",
+        "payload": { "$ref": "#/components/schemas/runDone" }
+      }
+    },
+    "schemas": {
+      "runDone": {
+        "type": "object",
+        "required": [],
+        "properties": { "datetime": { "type": "string" } }
+      },
+      "runStopped": {
+        "type": "object",
+        "required": [],
+        "properties": {
+          "datetime": { "type": "string" },
+          "reason": { "type": "string" }
+        }
+      },
+      "checkedForChanges": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "run_ids": {
+            "description": "List of run_id's that is the result of this check. None = nothing to do.",
+            "type": "array",
+            "items": { "type": "string" }
+          }
+        },
+        "additionalProperties": false
+      },
+      "runCheck": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "check_id": { "type": "string" },
+          "user_id": { "type": "string" }
+        },
+        "additionalProperties": false
+      },
+      "forceGeneration": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "run_id": { "type": "string" },
+          "generator_id": { "type": "string" },
+          "version": {
+            "type": "string",
+            "description": "version to use for the library instead of checking for changes"
+          }
+        }
+      },
+      "startRun": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "types": {
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "$id": "GeneratorTypes",
+            "type": "string",
+            "enum": ["openapi", "asyncapi"]
+          },
+          "openapi": {
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "$id": "OpenAPIGenerator",
+            "type": "object",
+            "required": [],
+            "properties": {
+              "language": {
+                "$ref": "#/components/schemas/startRun/properties/openapi/definitions/OpenAPIGenerators"
+              },
+              "version": { "type": "string" },
+              "documentContext": {
+                "$schema": "http://json-schema.org/draft-07/schema#",
+                "$id": "DocumentContext",
+                "type": "object",
+                "properties": {
+                  "specificationDocument": {
+                    "description": "The full spec file loaded into memory - Stringified",
+                    "type": "string"
+                  }
+                }
+              }
+            },
+            "allOf": [
+              {
+                "if": {
+                  "properties": {
+                    "language": {
+                      "$ref": "#/channels/runs.command.start.%7Btype%7D.%7Brun_uid%7D/subscribe/message/payload/properties/openapi/allOf/0/then/properties/typeScriptFetchSettings/x-language"
+                    }
+                  }
+                },
+                "then": {
+                  "properties": {
+                    "typeScriptFetchSettings": {
+                      "$schema": "http://json-schema.org/draft-07/schema#",
+                      "$id": "openapi_typescript_fetch",
+                      "type": "object",
+                      "properties": {
+                        "generatorVersion": {
+                          "description": "The precise version of the generator to be used",
+                          "type": "string"
+                        },
+                        "description": {
+                          "description": "The description of the released library, can contain markdown",
+                          "type": "string"
+                        },
+                        "title": {
+                          "description": "A representable title to use for the library. Difference with libraryName as this is not for machines.",
+                          "type": "string"
+                        },
+                        "npmReleaseConfig": {
+                          "$schema": "http://json-schema.org/draft-07/schema#",
+                          "$id": "npm-release",
+                          "type": "object",
+                          "description": "These configurations are required for publishing to NPM.",
+                          "properties": {
+                            "npmRepository": {
+                              "description": "The repository to release the library to",
+                              "type": "string",
+                              "default": "https://registry.npmjs.org"
+                            },
+                            "npmToken": {
+                              "description": "The token to use to release the library",
+                              "type": "string"
+                            },
+                            "npmName": {
+                              "description": "The npm name of the library to release in the form '@user/repo-name'",
+                              "type": "string"
+                            }
+                          },
+                          "required": ["npmRepository", "npmToken", "npmName"]
+                        }
+                      },
+                      "x-language": { "const": "typescript-fetch" },
+                      "required": ["generatorVersion"]
+                    }
+                  }
+                }
+              }
+            ],
+            "definitions": {
+              "OpenAPIGenerators": {
+                "$id": "OpenAPIGenerators",
+                "type": "string",
+                "oneOf": [
+                  {
+                    "$ref": "#/channels/runs.command.start.%7Btype%7D.%7Brun_uid%7D/subscribe/message/payload/properties/openapi/allOf/0/then/properties/typeScriptFetchSettings/x-language"
+                  }
+                ]
+              }
+            }
+          },
+          "asyncapi": {
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "$id": "AsyncAPIGenerator",
+            "type": "object",
+            "required": [],
+            "properties": {
+              "language": {
+                "$ref": "#/components/schemas/startRun/properties/asyncapi/definitions/AsyncAPIGenerators"
+              },
+              "version": { "type": "string" },
+              "documentContext": {
+                "$ref": "#/channels/runs.command.start.%7Btype%7D.%7Brun_uid%7D/subscribe/message/payload/properties/openapi/properties/documentContext"
+              }
+            },
+            "allOf": [
+              {
+                "if": {
+                  "properties": {
+                    "language": {
+                      "$ref": "#/channels/runs.command.start.%7Btype%7D.%7Brun_uid%7D/subscribe/message/payload/properties/asyncapi/allOf/0/then/properties/typeScriptNatsSettings/x-language"
+                    }
+                  }
+                },
+                "then": {
+                  "properties": {
+                    "typeScriptNatsSettings": {
+                      "$schema": "http://json-schema.org/draft-07/schema#",
+                      "$id": "typescript-nats-settings",
+                      "type": "object",
+                      "properties": {
+                        "generatorVersion": {
+                          "description": "The precise version of the generator to be used",
+                          "type": "string"
+                        },
+                        "description": {
+                          "description": "The description of the released library, can contain markdown",
+                          "type": "string"
+                        },
+                        "title": {
+                          "description": "A representable title to use for the library. Difference with libraryName is this is not for machines.",
+                          "type": "string"
+                        },
+                        "npmReleaseConfig": {
+                          "$ref": "#/channels/runs.command.start.%7Btype%7D.%7Brun_uid%7D/subscribe/message/payload/properties/openapi/allOf/0/then/properties/typeScriptFetchSettings/properties/npmReleaseConfig"
+                        }
+                      },
+                      "x-language": { "const": "typescript-nats" }
+                    }
+                  }
+                }
+              }
+            ],
+            "definitions": {
+              "AsyncAPIGenerators": {
+                "$id": "AsyncAPIGenerators",
+                "type": "string",
+                "oneOf": [
+                  {
+                    "$ref": "#/channels/runs.command.start.%7Btype%7D.%7Brun_uid%7D/subscribe/message/payload/properties/asyncapi/allOf/0/then/properties/typeScriptNatsSettings/x-language"
+                  }
+                ]
+              }
+            }
+          }
+        }
+      },
+      "logRun": {
+        "type": "object",
+        "required": [],
+        "properties": {
+          "datetime": { "type": "string" },
+          "message": { "type": "string" }
+        }
+      }
+    }
+  }
+}

--- a/src/codegen/generators/typescript/utils.ts
+++ b/src/codegen/generators/typescript/utils.ts
@@ -5,9 +5,9 @@ import {
   NO_RESERVED_KEYWORDS,
   typeScriptDefaultModelNameConstraints,
   typeScriptDefaultPropertyKeyConstraints,
-  TypeScriptOptions,
-} from "@asyncapi/modelina";
-import { DeepPartial } from "../../utils";
+  TypeScriptOptions
+} from '@asyncapi/modelina';
+import {DeepPartial} from '../../utils';
 
 /**
  * Component which contains the parameter unwrapping functionality.
@@ -32,7 +32,7 @@ export function unwrap(
 ) {
   // Nothing to unwrap if no parameters are used
   if (Object.keys(channelParameters.properties).length === 0) {
-    return "";
+    return '';
   }
 
   const parameterReplacement = Object.values(channelParameters.properties).map(
@@ -54,19 +54,19 @@ export function unwrap(
     }
   );
 
-  let topicWithWildcardGroup = channelName.replaceAll(/\//g, "\\/");
+  let topicWithWildcardGroup = channelName.replaceAll(/\//g, '\\/');
   topicWithWildcardGroup = topicWithWildcardGroup.replaceAll(
     /{[^}]+}/g,
-    "([^.]*)"
+    '([^.]*)'
   );
   const regexMatch = `/^${topicWithWildcardGroup}$/`;
 
   return `const regex = ${regexMatch};
-const parameters = new ${channelParameters.name}({${parameterInitializer.join(", ")}});
+const parameters = new ${channelParameters.name}({${parameterInitializer.join(', ')}});
 const match = msg.subject.match(regex);
 
 if (match) {
-  ${parameterReplacement.join("\n")}
+  ${parameterReplacement.join('\n')}
 } else {
   console.error(\`Was not able to retrieve parameters, ignoring message. Subject was: \${msg.subject}\`);
   return;
@@ -81,16 +81,16 @@ if (match) {
  */
 export function castToTsType(jsonSchemaType: string, variableToCast: string) {
   switch (jsonSchemaType.toLowerCase()) {
-    case "string": {
+    case 'string': {
       return `"" + ${variableToCast}`;
     }
 
-    case "integer":
-    case "number": {
+    case 'integer':
+    case 'number': {
       return `Number(${variableToCast})`;
     }
 
-    case "boolean": {
+    case 'boolean': {
       return `Boolean(${variableToCast})`;
     }
 
@@ -109,7 +109,7 @@ export function castToTsType(jsonSchemaType: string, variableToCast: string) {
 export function realizeParametersForChannelWithoutType(
   parameters: ConstrainedObjectModel
 ) {
-  let returnString = "";
+  let returnString = '';
   for (const paramName in Object.keys(parameters.properties)) {
     returnString += `${paramName},`;
   }
@@ -130,7 +130,7 @@ export function realizeParametersForChannel(
   channelParameters: ConstrainedObjectModel,
   required = true
 ) {
-  let returnString = "";
+  let returnString = '';
   for (const parameter of Object.values(channelParameters.properties)) {
     returnString += `${realizeParameterForChannelWithType(parameter.propertyName, parameter.property.type, required)},`;
   }
@@ -154,7 +154,7 @@ function realizeParameterForChannelWithType(
   parameterType: string,
   required = true
 ) {
-  const requiredType = required ? "" : "?";
+  const requiredType = required ? '' : '?';
   return `${parameterName}${requiredType}: ${parameterType})}`;
 }
 
@@ -170,7 +170,7 @@ export function renderJSDocParameters(
     .map((paramName) => {
       return `* @param ${paramName} parameter to use in topic`;
     })
-    .join("\n");
+    .join('\n');
 }
 
 /**
@@ -181,7 +181,7 @@ export function realizeChannelName(
   parameters?: ConstrainedObjectModel
 ) {
   let returnString = `\`${channelName}\``;
-  returnString = returnString.replaceAll("/", ".");
+  returnString = returnString.replaceAll('/', '.');
   for (const paramName in parameters) {
     returnString = returnString.replace(`{${paramName}}`, `\${${paramName}}`);
   }
@@ -207,68 +207,68 @@ export function pascalCase(value: string) {
 }
 
 export const RESERVED_TYPESCRIPT_KEYWORDS = [
-  "break",
-  "case",
-  "catch",
-  "class",
-  "const",
-  "continue",
-  "debugger",
-  "default",
-  "delete",
-  "do",
-  "else",
-  "enum",
-  "export",
-  "extends",
-  "false",
-  "finally",
-  "for",
-  "function",
-  "if",
-  "import",
-  "in",
-  "instanceof",
-  "new",
-  "null",
-  "return",
-  "super",
-  "switch",
-  "this",
-  "throw",
-  "true",
-  "try",
-  "typeof",
-  "var",
-  "void",
-  "while",
-  "with",
-  "any",
-  "boolean",
-  "constructor",
-  "declare",
-  "get",
-  "module",
-  "require",
-  "number",
-  "set",
-  "string",
-  "symbol",
-  "type",
-  "from",
-  "of",
+  'break',
+  'case',
+  'catch',
+  'class',
+  'const',
+  'continue',
+  'debugger',
+  'default',
+  'delete',
+  'do',
+  'else',
+  'enum',
+  'export',
+  'extends',
+  'false',
+  'finally',
+  'for',
+  'function',
+  'if',
+  'import',
+  'in',
+  'instanceof',
+  'new',
+  'null',
+  'return',
+  'super',
+  'switch',
+  'this',
+  'throw',
+  'true',
+  'try',
+  'typeof',
+  'var',
+  'void',
+  'while',
+  'with',
+  'any',
+  'boolean',
+  'constructor',
+  'declare',
+  'get',
+  'module',
+  'require',
+  'number',
+  'set',
+  'string',
+  'symbol',
+  'type',
+  'from',
+  'of',
   // Strict mode reserved words
-  "arguments",
-  "as",
-  "implements",
-  "interface",
-  "let",
-  "package",
-  "private",
-  "protected",
-  "public",
-  "static",
-  "yield",
+  'arguments',
+  'as',
+  'implements',
+  'interface',
+  'let',
+  'package',
+  'private',
+  'protected',
+  'public',
+  'static',
+  'yield'
 ];
 
 export const defaultCodegenTypescriptModelinaOptions: DeepPartial<TypeScriptOptions> =
@@ -281,8 +281,8 @@ export const defaultCodegenTypescriptModelinaOptions: DeepPartial<TypeScriptOpti
         },
         NO_SPECIAL_CHAR: (name) => {
           // Looks nicer with no special cases at all
-          return name.replace(/\W/g, " ");
-        },
+          return name.replace(/\W/g, ' ');
+        }
       }),
       propertyKey: typeScriptDefaultPropertyKeyConstraints({
         NO_RESERVED_KEYWORDS: (value) => {
@@ -291,12 +291,12 @@ export const defaultCodegenTypescriptModelinaOptions: DeepPartial<TypeScriptOpti
             checkForReservedKeyword(
               word,
               RESERVED_TYPESCRIPT_KEYWORDS.filter((filteredValue) => {
-                return filteredValue !== "type";
+                return filteredValue !== 'type';
               }),
               true
             )
           );
-        },
-      }),
-    },
+        }
+      })
+    }
   };

--- a/src/codegen/generators/typescript/utils.ts
+++ b/src/codegen/generators/typescript/utils.ts
@@ -5,9 +5,9 @@ import {
   NO_RESERVED_KEYWORDS,
   typeScriptDefaultModelNameConstraints,
   typeScriptDefaultPropertyKeyConstraints,
-  TypeScriptOptions
-} from '@asyncapi/modelina';
-import {DeepPartial} from '../../utils';
+  TypeScriptOptions,
+} from "@asyncapi/modelina";
+import { DeepPartial } from "../../utils";
 
 /**
  * Component which contains the parameter unwrapping functionality.
@@ -32,7 +32,7 @@ export function unwrap(
 ) {
   // Nothing to unwrap if no parameters are used
   if (Object.keys(channelParameters.properties).length === 0) {
-    return '';
+    return "";
   }
 
   const parameterReplacement = Object.values(channelParameters.properties).map(
@@ -43,23 +43,30 @@ export function unwrap(
 
   const parameterInitializer = Object.values(channelParameters.properties).map(
     (parameter, index) => {
+      if (parameter.property.options.isNullable) {
+        return `${parameter.propertyName}: null`;
+      }
+      if (parameter.property.originalInput.enum) {
+        return `${parameter.propertyName}: '${parameter.property.originalInput.enum.at(0)}`;
+      }
+
       return `${parameter.propertyName}: ''`;
     }
   );
 
-  let topicWithWildcardGroup = channelName.replaceAll(/\//g, '\\/');
+  let topicWithWildcardGroup = channelName.replaceAll(/\//g, "\\/");
   topicWithWildcardGroup = topicWithWildcardGroup.replaceAll(
     /{[^}]+}/g,
-    '([^.]*)'
+    "([^.]*)"
   );
   const regexMatch = `/^${topicWithWildcardGroup}$/`;
 
   return `const regex = ${regexMatch};
-const parameters = new ${channelParameters.name}({${parameterInitializer.join(', ')}});
+const parameters = new ${channelParameters.name}({${parameterInitializer.join(", ")}});
 const match = msg.subject.match(regex);
 
 if (match) {
-  ${parameterReplacement.join('\n')}
+  ${parameterReplacement.join("\n")}
 } else {
   console.error(\`Was not able to retrieve parameters, ignoring message. Subject was: \${msg.subject}\`);
   return;
@@ -74,16 +81,16 @@ if (match) {
  */
 export function castToTsType(jsonSchemaType: string, variableToCast: string) {
   switch (jsonSchemaType.toLowerCase()) {
-    case 'string': {
+    case "string": {
       return `"" + ${variableToCast}`;
     }
 
-    case 'integer':
-    case 'number': {
+    case "integer":
+    case "number": {
       return `Number(${variableToCast})`;
     }
 
-    case 'boolean': {
+    case "boolean": {
       return `Boolean(${variableToCast})`;
     }
 
@@ -102,7 +109,7 @@ export function castToTsType(jsonSchemaType: string, variableToCast: string) {
 export function realizeParametersForChannelWithoutType(
   parameters: ConstrainedObjectModel
 ) {
-  let returnString = '';
+  let returnString = "";
   for (const paramName in Object.keys(parameters.properties)) {
     returnString += `${paramName},`;
   }
@@ -123,7 +130,7 @@ export function realizeParametersForChannel(
   channelParameters: ConstrainedObjectModel,
   required = true
 ) {
-  let returnString = '';
+  let returnString = "";
   for (const parameter of Object.values(channelParameters.properties)) {
     returnString += `${realizeParameterForChannelWithType(parameter.propertyName, parameter.property.type, required)},`;
   }
@@ -147,7 +154,7 @@ function realizeParameterForChannelWithType(
   parameterType: string,
   required = true
 ) {
-  const requiredType = required ? '' : '?';
+  const requiredType = required ? "" : "?";
   return `${parameterName}${requiredType}: ${parameterType})}`;
 }
 
@@ -163,7 +170,7 @@ export function renderJSDocParameters(
     .map((paramName) => {
       return `* @param ${paramName} parameter to use in topic`;
     })
-    .join('\n');
+    .join("\n");
 }
 
 /**
@@ -174,7 +181,7 @@ export function realizeChannelName(
   parameters?: ConstrainedObjectModel
 ) {
   let returnString = `\`${channelName}\``;
-  returnString = returnString.replaceAll('/', '.');
+  returnString = returnString.replaceAll("/", ".");
   for (const paramName in parameters) {
     returnString = returnString.replace(`{${paramName}}`, `\${${paramName}}`);
   }
@@ -200,68 +207,68 @@ export function pascalCase(value: string) {
 }
 
 export const RESERVED_TYPESCRIPT_KEYWORDS = [
-  'break',
-  'case',
-  'catch',
-  'class',
-  'const',
-  'continue',
-  'debugger',
-  'default',
-  'delete',
-  'do',
-  'else',
-  'enum',
-  'export',
-  'extends',
-  'false',
-  'finally',
-  'for',
-  'function',
-  'if',
-  'import',
-  'in',
-  'instanceof',
-  'new',
-  'null',
-  'return',
-  'super',
-  'switch',
-  'this',
-  'throw',
-  'true',
-  'try',
-  'typeof',
-  'var',
-  'void',
-  'while',
-  'with',
-  'any',
-  'boolean',
-  'constructor',
-  'declare',
-  'get',
-  'module',
-  'require',
-  'number',
-  'set',
-  'string',
-  'symbol',
-  'type',
-  'from',
-  'of',
+  "break",
+  "case",
+  "catch",
+  "class",
+  "const",
+  "continue",
+  "debugger",
+  "default",
+  "delete",
+  "do",
+  "else",
+  "enum",
+  "export",
+  "extends",
+  "false",
+  "finally",
+  "for",
+  "function",
+  "if",
+  "import",
+  "in",
+  "instanceof",
+  "new",
+  "null",
+  "return",
+  "super",
+  "switch",
+  "this",
+  "throw",
+  "true",
+  "try",
+  "typeof",
+  "var",
+  "void",
+  "while",
+  "with",
+  "any",
+  "boolean",
+  "constructor",
+  "declare",
+  "get",
+  "module",
+  "require",
+  "number",
+  "set",
+  "string",
+  "symbol",
+  "type",
+  "from",
+  "of",
   // Strict mode reserved words
-  'arguments',
-  'as',
-  'implements',
-  'interface',
-  'let',
-  'package',
-  'private',
-  'protected',
-  'public',
-  'static',
-  'yield'
+  "arguments",
+  "as",
+  "implements",
+  "interface",
+  "let",
+  "package",
+  "private",
+  "protected",
+  "public",
+  "static",
+  "yield",
 ];
 
 export const defaultCodegenTypescriptModelinaOptions: DeepPartial<TypeScriptOptions> =
@@ -274,8 +281,8 @@ export const defaultCodegenTypescriptModelinaOptions: DeepPartial<TypeScriptOpti
         },
         NO_SPECIAL_CHAR: (name) => {
           // Looks nicer with no special cases at all
-          return name.replace(/\W/g, ' ');
-        }
+          return name.replace(/\W/g, " ");
+        },
       }),
       propertyKey: typeScriptDefaultPropertyKeyConstraints({
         NO_RESERVED_KEYWORDS: (value) => {
@@ -284,12 +291,12 @@ export const defaultCodegenTypescriptModelinaOptions: DeepPartial<TypeScriptOpti
             checkForReservedKeyword(
               word,
               RESERVED_TYPESCRIPT_KEYWORDS.filter((filteredValue) => {
-                return filteredValue !== 'type';
+                return filteredValue !== "type";
               }),
               true
             )
           );
-        }
-      })
-    }
+        },
+      }),
+    },
   };


### PR DESCRIPTION
Issue:
![image](https://github.com/user-attachments/assets/1a9c5684-53d4-4ebf-a505-1bd7a7697b40)
The default value for an enum type is an empty string so typescript won't build the channel index.ts file.
Fix:
The fix involves checking if the type is an enum and then just defaulting to the first in the enum array.
![image](https://github.com/user-attachments/assets/565750d1-fbac-4465-b51d-5d7ddb1fa020)

- I don't know if this is this "right" way to fix it.
- Don't know if the added playground makes any sense. However I was testing by using the playground folder with a codegen.ts file and running `npm exec codegen generate` which works fine. 

- [x] Fix linting issue
