### PR TITLE
chore(release): v0.32.0

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -53,3 +53,4 @@ Each protocol has its own limitations, corner cases, and features; thus, each ha
 
 
 
+

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -141,3 +141,4 @@ Prefix that follows specification is not enough though. Remember that the title 
 
 
 
+

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -9,7 +9,7 @@ $ npm install -g @the-codegen-project/cli
 $ codegen COMMAND
 running command...
 $ codegen (--version)
-@the-codegen-project/cli/0.31.0 linux-x64 node-v18.20.6
+@the-codegen-project/cli/0.32.0 linux-x64 node-v18.20.6
 $ codegen --help [COMMAND]
 USAGE
   $ codegen COMMAND
@@ -81,7 +81,7 @@ DESCRIPTION
   Generate code based on your configuration, use `init` to get started.
 ```
 
-_See code: [src/commands/generate.ts](https://github.com/the-codegen-project/cli/blob/v0.31.0/src/commands/generate.ts)_
+_See code: [src/commands/generate.ts](https://github.com/the-codegen-project/cli/blob/v0.32.0/src/commands/generate.ts)_
 
 ## `codegen help [COMMAND]`
 
@@ -139,7 +139,7 @@ DESCRIPTION
   Initialize The Codegen Project in your project
 ```
 
-_See code: [src/commands/init.ts](https://github.com/the-codegen-project/cli/blob/v0.31.0/src/commands/init.ts)_
+_See code: [src/commands/init.ts](https://github.com/the-codegen-project/cli/blob/v0.32.0/src/commands/init.ts)_
 
 ## `codegen version`
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@the-codegen-project/cli",
-  "version": "0.31.0",
+  "version": "0.32.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@the-codegen-project/cli",
-      "version": "0.31.0",
+      "version": "0.32.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@asyncapi/avro-schema-parser": "^3.0.22",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@the-codegen-project/cli",
   "description": "CLI to work with code generation in any environment",
-  "version": "0.31.0",
+  "version": "0.32.0",
   "bin": {
     "codegen": "./bin/run.mjs"
   },


### PR DESCRIPTION
Version bump in package.json for release [v0.32.0](https://github.com/the-codegen-project/cli/releases/tag/v0.32.0)