### PR TITLE
feat: convert all channel parameters to object

### DIFF
--- a/docs/architectural-decisions/typescript.md
+++ b/docs/architectural-decisions/typescript.md
@@ -8,3 +8,7 @@ All decision worth mentioning about TypeScript can be found here, simply to keep
 ### 21.08.2024
 
 1. All functions in channel protocols are to be designed arrow function as it's more versatile when combining it together with other code sections.
+
+### 28.04.2025
+
+1. All function parameters MUST be object parameters to better support many optional parameters without having to write `functionCall(undefined, undefined, 'value')`

--- a/docs/generators/client.md
+++ b/docs/generators/client.md
@@ -96,7 +96,7 @@ export class NatsClient {
   /**
    * Try to connect to the NATS server with the different payloads.
    */
-  connect(options: Nats.ConnectionOptions, codec?: Nats.Codec<any>): Promise<void> {
+  connect(options: Nats.ConnectionOptions, codec?: Nats.Codec<any><any>): Promise<void> {
     ...
   }
   

--- a/docs/migrations/0.md
+++ b/docs/migrations/0.md
@@ -1,0 +1,51 @@
+---
+sidebar_position: 99
+---
+
+# Migrating between v0
+These are all the breaking changes in v0 and how to migrate between them.
+
+## Breaking Changes 0.39.0
+
+### Functions Parameters
+
+All TypeScript functions now [use object parameters](../architectural-decisions/typescript.md#28042025) instead of regular parameters. This change affects `channels` and `client` generators across all protocols.
+
+Before:
+```typescript
+// Publishing
+await jetStreamPublishToSendUserSignedup(message, parameters, js);
+await publishToSendUserSignedup(message, parameters, connection);
+
+// Subscribing
+const subscriber = await jetStreamPullSubscribeToReceiveUserSignedup(
+  onDataCallback,
+  parameters,
+  js,
+  config
+);
+```
+
+After:
+```typescript
+// Publishing
+await jetStreamPublishToSendUserSignedup({
+  message,
+  parameters,
+  js
+});
+await publishToSendUserSignedup({
+  message,
+  parameters,
+  connection
+});
+
+// Subscribing
+const subscriber = await jetStreamPullSubscribeToReceiveUserSignedup({
+  onDataCallback,
+  parameters,
+  js,
+  config
+});
+```
+

--- a/docs/migrations/_category_.json
+++ b/docs/migrations/_category_.json
@@ -1,0 +1,8 @@
+{
+  "label": "Protocols",
+  "position": 99,
+  "link": {
+    "type": "generated-index",
+    "description": "All the available protocols you can use along side which inputs and generators are supported."
+  }
+}

--- a/src/codegen/generators/typescript/channels/protocols/amqp/publishExchange.ts
+++ b/src/codegen/generators/typescript/channels/protocols/amqp/publishExchange.ts
@@ -30,23 +30,29 @@ channel.publish(exchange, routingKey, Buffer.from(dataToSend), options);`;
 
   const functionParameters = [
     {
-      parameter: `message: ${messageType}`,
+      parameter: `message`,
+      parameterType: `message: ${messageType}`,
       jsDoc: ' * @param message to publish'
     },
     ...(channelParameters
       ? [
           {
-            parameter: `parameters: ${channelParameters.type}`,
+            parameter: `parameters`,
+            parameterType: `parameters: ${channelParameters.type}`,
             jsDoc: ' * @param parameters for topic substitution'
           }
         ]
       : []),
+
     {
-      parameter: 'amqp: Amqp.Connection',
+      parameter: 'amqp',
+      parameterType: 'amqp: Amqp.Connection',
       jsDoc: ' * @param amqp the AMQP connection to send over'
     },
     {
-      parameter: `options?: {exchange: string | undefined} & Amqp.Options.Publish`
+      parameter: `options`,
+      parameterType: `options?: {exchange: string | undefined} & Amqp.Options.Publish`,
+      jsDoc: ' * @param options for the AMQP publish exchange operation'
     }
   ];
 
@@ -55,10 +61,12 @@ channel.publish(exchange, routingKey, Buffer.from(dataToSend), options);`;
  * 
  ${functionParameters.map((param) => param.jsDoc).join('\n')}
  */
-${functionName}: (
-  ${functionParameters.map((param) => param.parameter).join(', ')}
-): Promise<void> => {
-  return new Promise<void>(async (resolve, reject) => {    
+${functionName}: ({
+  ${functionParameters.map((param) => param.parameter).join(', \n  ')}
+}: {
+  ${functionParameters.map((param) => param.parameterType).join(', \n  ')}
+}): Promise<void> => {
+  return new Promise<void>(async (resolve, reject) => {
     const exchange = options?.exchange ?? '${additionalProperties?.exchange}';
     if(!exchange) {
       return reject('No exchange value found, please provide one')

--- a/src/codegen/generators/typescript/channels/protocols/amqp/publishQueue.ts
+++ b/src/codegen/generators/typescript/channels/protocols/amqp/publishQueue.ts
@@ -27,23 +27,28 @@ channel.sendToQueue(queue, Buffer.from(dataToSend), options);`;
 
   const functionParameters = [
     {
-      parameter: `message: ${messageType}`,
+      parameter: `message`,
+      parameterType: `message: ${messageType}`,
       jsDoc: ' * @param message to publish'
     },
     ...(channelParameters
       ? [
           {
-            parameter: `parameters: ${channelParameters.type}`,
+            parameter: `parameters`,
+            parameterType: `parameters: ${channelParameters.type}`,
             jsDoc: ' * @param parameters for topic substitution'
           }
         ]
       : []),
     {
-      parameter: 'amqp: Amqp.Connection',
+      parameter: 'amqp',
+      parameterType: 'amqp: Amqp.Connection',
       jsDoc: ' * @param amqp the AMQP connection to send over'
     },
     {
-      parameter: `options?: Amqp.Options.Publish`
+      parameter: `options`,
+      parameterType: `options?: Amqp.Options.Publish`,
+      jsDoc: ' * @param options for the AMQP publish queue operation'
     }
   ];
 
@@ -52,9 +57,11 @@ channel.sendToQueue(queue, Buffer.from(dataToSend), options);`;
  * 
  ${functionParameters.map((param) => param.jsDoc).join('\n')}
  */
-${functionName}: (
-  ${functionParameters.map((param) => param.parameter).join(', ')}
-): Promise<void> => {
+${functionName}: ({
+  ${functionParameters.map((param) => param.parameter).join(', \n  ')}
+}: {
+  ${functionParameters.map((param) => param.parameterType).join(', \n  ')}
+}): Promise<void> => {
   return new Promise<void>(async (resolve, reject) => {
     try {
       ${publishOperation}

--- a/src/codegen/generators/typescript/channels/protocols/amqp/subscribeQueue.ts
+++ b/src/codegen/generators/typescript/channels/protocols/amqp/subscribeQueue.ts
@@ -56,26 +56,32 @@ channel.consume(queue, (msg) => {
   ];
   const functionParameters = [
     {
-      parameter: `onDataCallback: (${callbackFunctionParameters.map((param) => param.parameter).join(', ')}) => void`,
+      parameter: `onDataCallback`,
+      parameterType: `onDataCallback: (${callbackFunctionParameters.map((param) => param.parameter).join(', ')}) => void`,
       jsDoc: ` * @param {${functionName}Callback} onDataCallback to call when messages are received`
     },
     ...(channelParameters
       ? [
           {
-            parameter: `parameters: ${channelParameters.type}`,
+            parameter: `parameters`,
+            parameterType: `parameters: ${channelParameters.type}`,
             jsDoc: ' * @param parameters for topic substitution'
           }
         ]
       : []),
     {
-      parameter: 'amqp: Amqp.Connection',
+      parameter: 'amqp',
+      parameterType: 'amqp: Amqp.Connection',
       jsDoc: ' * @param amqp the AMQP connection to receive from'
     },
     {
-      parameter: `options?: Amqp.Options.Consume`
+      parameter: `options`,
+      parameterType: `options?: Amqp.Options.Consume`,
+      jsDoc: ' * @param options for the AMQP subscribe queue operation'
     },
     {
-      parameter: 'skipMessageValidation: boolean = false',
+      parameter: 'skipMessageValidation = false',
+      parameterType: 'skipMessageValidation?: boolean',
       jsDoc:
         ' * @param skipMessageValidation turn off runtime validation of incoming messages'
     }
@@ -86,9 +92,11 @@ channel.consume(queue, (msg) => {
  * 
  ${functionParameters.map((param) => param.jsDoc).join('\n')}
  */
-${functionName}: (
-  ${functionParameters.map((param) => param.parameter).join(',\n  ')}
-): Promise<Amqp.Channel> => {
+${functionName}: ({
+  ${functionParameters.map((param) => param.parameter).join(', \n  ')}
+}: {
+  ${functionParameters.map((param) => param.parameterType).join(', \n  ')}
+}): Promise<Amqp.Channel> => {
   return new Promise(async (resolve, reject) => {
     try {
       ${subscribeOperation}

--- a/src/codegen/generators/typescript/channels/protocols/eventsource/express.ts
+++ b/src/codegen/generators/typescript/channels/protocols/eventsource/express.ts
@@ -25,15 +25,15 @@ export function renderExpress({
   const callbackFunctionParameters = [
     {
       parameter: 'req: Request',
-      jsDoc: ' * @param req '
+      jsDoc: ' * @param req from the request'
     },
     {
       parameter: 'res: Response',
-      jsDoc: ' * @param res'
+      jsDoc: ' * @param res from the request'
     },
     {
       parameter: 'next: NextFunction',
-      jsDoc: ' * @param next'
+      jsDoc: ' * @param next attached to the request'
     },
     ...(channelParameters
       ? [
@@ -52,18 +52,22 @@ export function renderExpress({
   ];
   const functionParameters = [
     {
-      parameter: 'router: Router',
-      jsDoc: ' * @param router '
+      parameter: 'router',
+      parameterType: 'router: Router',
+      jsDoc: ' * @param router to attach the event source to'
     },
     {
-      parameter: `callback: ((${callbackFunctionParameters.map((param) => param.parameter).join(', ')}) => void) | ((${callbackFunctionParameters.map((param) => param.parameter).join(', ')}) => Promise<void>)`,
+      parameter: `callback`,
+      parameterType: `callback: ((${callbackFunctionParameters.map((param) => param.parameter).join(', ')}) => void) | ((${callbackFunctionParameters.map((param) => param.parameter).join(', ')}) => Promise<void>)`,
       jsDoc: ' * @param callback to call when receiving events'
     }
   ];
 
-  const code = `${functionName}: (
+  const code = `${functionName}: ({
   ${functionParameters.map((param) => param.parameter).join(', \n  ')}
-) => {
+}: {
+  ${functionParameters.map((param) => param.parameterType).join(', \n  ')}
+}) => {
   const event = '${addressToUse}';
   router.get(event, async (req, res, next) => {
     ${channelParameters ? `const listenParameters = ${channelParameters.type}.createFromChannel(req.originalUrl.startsWith('/') ? req.originalUrl.slice(1) : req.originalUrl, '${topic}', ${findRegexFromChannel(topic)});` : ''}

--- a/src/codegen/generators/typescript/channels/protocols/eventsource/fetch.ts
+++ b/src/codegen/generators/typescript/channels/protocols/eventsource/fetch.ts
@@ -38,24 +38,27 @@ export function renderFetch({
     });
   const functionParameters = [
     {
-      parameter: `callback: (error?: Error, messageEvent?: ${messageType}) => void`,
+      parameter: `callback`,
+      parameterType: `callback: (error?: Error, messageEvent?: ${messageType}) => void`,
       jsDoc: ' * @param callback to call when receiving events'
     },
     ...(channelParameters
       ? [
           {
-            parameter: `parameters: ${channelParameters.type}`,
+            parameter: `parameters`,
+            parameterType: `parameters: ${channelParameters.type}`,
             jsDoc: ' * @param parameters for listening'
           }
         ]
       : []),
     {
-      parameter:
-        'options: {authorization?: string, onClose?: (err?: string) => void, baseUrl: string, headers?: Record<string, string>}',
+      parameter: 'options',
+      parameterType: `options: {authorization?: string, onClose?: (err?: string) => void, baseUrl: string, headers?: Record<string, string>}`,
       jsDoc: ' * @param options additionally used to handle the event source'
     },
     {
-      parameter: 'skipMessageValidation: boolean = false',
+      parameter: 'skipMessageValidation = false',
+      parameterType: 'skipMessageValidation?: boolean',
       jsDoc:
         ' * @param skipMessageValidation turn off runtime validation of incoming messages'
     }
@@ -66,9 +69,11 @@ export function renderFetch({
  * 
  ${functionParameters.map((param) => param.jsDoc).join('\n')}
  */
-${functionName}: async (
+${functionName}: async ({
   ${functionParameters.map((param) => param.parameter).join(', \n  ')}
-) => {
+}: {
+  ${functionParameters.map((param) => param.parameterType).join(', \n  ')}
+}) => {
 	let eventsUrl: string = ${addressToUse};
 	const url = \`\${options.baseUrl}/\${eventsUrl}\`
   const headers: Record<string, string> = {

--- a/src/codegen/generators/typescript/channels/protocols/kafka/publish.ts
+++ b/src/codegen/generators/typescript/channels/protocols/kafka/publish.ts
@@ -27,19 +27,22 @@ export function renderPublish({
 
   const functionParameters = [
     {
-      parameter: `message: ${messageType}`,
+      parameter: `message`,
+      parameterType: `message: ${messageType}`,
       jsDoc: ' * @param message to publish'
     },
     ...(channelParameters
       ? [
           {
-            parameter: `parameters: ${channelParameters.type}`,
+            parameter: `parameters`,
+            parameterType: `parameters: ${channelParameters.type}`,
             jsDoc: ' * @param parameters for topic substitution'
           }
         ]
       : []),
     {
-      parameter: 'kafka: Kafka.Kafka',
+      parameter: 'kafka',
+      parameterType: 'kafka: Kafka.Kafka',
       jsDoc: ' * @param kafka the KafkaJS client to publish from'
     }
   ];
@@ -49,9 +52,11 @@ export function renderPublish({
  * 
  ${functionParameters.map((param) => param.jsDoc).join('\n')}
  */
-${functionName}: (
-  ${functionParameters.map((param) => param.parameter).join(', ')}
-): Promise<Kafka.Producer> => {
+${functionName}: ({
+  ${functionParameters.map((param) => param.parameter).join(', \n  ')}
+}: {
+  ${functionParameters.map((param) => param.parameterType).join(', \n  ')}
+}): Promise<Kafka.Producer> => {
   return new Promise(async (resolve, reject) => {
     try {
       ${publishOperation}

--- a/src/codegen/generators/typescript/channels/protocols/kafka/subscribe.ts
+++ b/src/codegen/generators/typescript/channels/protocols/kafka/subscribe.ts
@@ -4,6 +4,7 @@ import {ChannelFunctionTypes} from '../..';
 import {SingleFunctionRenderType} from '../../../../../types';
 import {findRegexFromChannel, pascalCase} from '../../../utils';
 import {RenderRegularParameters} from '../../types';
+import {getValidationFunctions} from '../../utils';
 
 export function renderSubscribe({
   topic,
@@ -11,13 +12,25 @@ export function renderSubscribe({
   messageModule,
   channelParameters,
   subName = pascalCase(topic),
-  functionName = `consumeFrom${subName}`
+  functionName = `consumeFrom${subName}`,
+  payloadGenerator
 }: RenderRegularParameters): SingleFunctionRenderType {
+  const includeValidation = payloadGenerator.generator.includeValidation;
   const addressToUse = channelParameters
     ? `parameters.getChannelWithParameters('${topic}')`
     : `'${topic}'`;
-  const messageUnmarshalling = `${messageModule ?? messageType}.unmarshal(message.value?.toString()!)`;
+  const messageUnmarshalling = `${messageModule ?? messageType}.unmarshal(receivedData)`;
   messageType = messageModule ? `${messageModule}.${messageType}` : messageType;
+
+  const {potentialValidatorCreation, potentialValidationFunction} =
+    getValidationFunctions({
+      includeValidation,
+      messageModule,
+      messageType,
+      onValidationFail: channelParameters
+        ? `return onDataCallback(new Error('Invalid message payload received', {cause: errors}), undefined, parameters, kafkaMessage);`
+        : `return onDataCallback(new Error('Invalid message payload received', {cause: errors}), undefined, kafkaMessage);`
+    });
 
   const callbackFunctionParameters = [
     {
@@ -63,6 +76,11 @@ export function renderSubscribe({
       parameter:
         "options: {fromBeginning: boolean, groupId: string} = {fromBeginning: true, groupId: ''}",
       jsDoc: ' * @param options when setting up the subscription'
+    },
+    {
+      parameter: 'skipMessageValidation: boolean = false',
+      jsDoc:
+        ' * @param skipMessageValidation turn off runtime validation of outgoing messages'
     }
   ];
   let whenReceivingMessage = '';
@@ -70,14 +88,16 @@ export function renderSubscribe({
     if (messageType === 'null') {
       whenReceivingMessage = `onDataCallback(undefined, null, parameters, kafkaMessage);`;
     } else {
-      whenReceivingMessage = `const callbackData = ${messageUnmarshalling};
+      whenReceivingMessage = `${potentialValidationFunction}
+const callbackData = ${messageUnmarshalling};
 onDataCallback(undefined, callbackData, parameters, kafkaMessage);`;
     }
   } else if (messageType === 'null') {
     whenReceivingMessage = `onDataCallback(undefined, null, kafkaMessage);`;
   } else {
-    whenReceivingMessage = `const callbackData = ${messageUnmarshalling};
-  onDataCallback(undefined, callbackData, kafkaMessage);`;
+    whenReceivingMessage = `${potentialValidationFunction}
+const callbackData = ${messageUnmarshalling};
+onDataCallback(undefined, callbackData, kafkaMessage);`;
   }
   const jsDocParameters = functionParameters
     .map((param) => param.jsDoc)
@@ -104,15 +124,17 @@ ${functionName}: (
   return new Promise(async (resolve, reject) => {
     try {
       if(!options.groupId) {
-        reject('No group ID provided');
+        return reject('No group ID provided');
       }
       const consumer = kafka.consumer({ groupId: options.groupId });
 
+      ${potentialValidatorCreation}
       await consumer.connect();
       await consumer.subscribe({ topic: ${addressToUse}, fromBeginning: options.fromBeginning });
       await consumer.run({
         eachMessage: async (kafkaMessage: Kafka.EachMessagePayload) => {
           const { topic, message } = kafkaMessage;
+          const receivedData = message.value?.toString()!;
           ${channelParameters ? `const parameters = ${channelParameters.type}.createFromChannel(topic, '${topic}', ${findRegexFromChannel(topic)});` : ''}
           ${whenReceivingMessage}
         }

--- a/src/codegen/generators/typescript/channels/protocols/kafka/subscribe.ts
+++ b/src/codegen/generators/typescript/channels/protocols/kafka/subscribe.ts
@@ -57,30 +57,34 @@ export function renderSubscribe({
 
   const functionParameters = [
     {
-      parameter: `onDataCallback: (${callbackFunctionParameters.map((param) => param.parameter).join(', ')}) => void`,
+      parameter: `onDataCallback`,
+      parameterType: `onDataCallback: (${callbackFunctionParameters.map((param) => param.parameter).join(', ')}) => void`,
       jsDoc: ` * @param {${functionName}Callback} onDataCallback to call when messages are received`
     },
     ...(channelParameters
       ? [
           {
-            parameter: `parameters: ${channelParameters.type}`,
+            parameter: `parameters`,
+            parameterType: `parameters: ${channelParameters.type}`,
             jsDoc: ' * @param parameters for topic substitution'
           }
         ]
       : []),
     {
-      parameter: 'kafka: Kafka.Kafka',
+      parameter: 'kafka',
+      parameterType: 'kafka: Kafka.Kafka',
       jsDoc: ' * @param kafka the KafkaJS client to subscribe through'
     },
     {
-      parameter:
-        "options: {fromBeginning: boolean, groupId: string} = {fromBeginning: true, groupId: ''}",
+      parameter: `options = {fromBeginning: true, groupId: ''}`,
+      parameterType: `options: {fromBeginning: boolean, groupId: string}`,
       jsDoc: ' * @param options when setting up the subscription'
     },
     {
-      parameter: 'skipMessageValidation: boolean = false',
+      parameter: 'skipMessageValidation = false',
+      parameterType: 'skipMessageValidation?: boolean',
       jsDoc:
-        ' * @param skipMessageValidation turn off runtime validation of outgoing messages'
+        ' * @param skipMessageValidation turn off runtime validation of incoming messages'
     }
   ];
   let whenReceivingMessage = '';
@@ -118,9 +122,11 @@ onDataCallback(undefined, callbackData, kafkaMessage);`;
  * 
  ${jsDocParameters}
  */
-${functionName}: (
-  ${functionParameters.map((param) => param.parameter).join(', ')}
-): Promise<Kafka.Consumer> => {
+${functionName}: ({
+  ${functionParameters.map((param) => param.parameter).join(', \n  ')}
+}: {
+  ${functionParameters.map((param) => param.parameterType).join(', \n  ')}
+}): Promise<Kafka.Consumer> => {
   return new Promise(async (resolve, reject) => {
     try {
       if(!options.groupId) {

--- a/src/codegen/generators/typescript/channels/protocols/mqtt/publish.ts
+++ b/src/codegen/generators/typescript/channels/protocols/mqtt/publish.ts
@@ -28,19 +28,22 @@ mqtt.publish(${addressToUse}, dataToSend);`;
 
   const functionParameters = [
     {
-      parameter: `message: ${messageType}`,
+      parameter: `message`,
+      parameterType: `message: ${messageType}`,
       jsDoc: ' * @param message to publish'
     },
     ...(channelParameters
       ? [
           {
-            parameter: `parameters: ${channelParameters.type}`,
+            parameter: `parameters`,
+            parameterType: `parameters: ${channelParameters.type}`,
             jsDoc: ' * @param parameters for topic substitution'
           }
         ]
       : []),
     {
-      parameter: 'mqtt: Mqtt.MqttClient',
+      parameter: 'mqtt',
+      parameterType: 'mqtt: Mqtt.MqttClient',
       jsDoc: ' * @param mqtt the MQTT client to publish from'
     }
   ];
@@ -50,9 +53,11 @@ mqtt.publish(${addressToUse}, dataToSend);`;
  * 
  ${functionParameters.map((param) => param.jsDoc).join('\n')}
  */
-${functionName}: (
-  ${functionParameters.map((param) => param.parameter).join(', ')}
-): Promise<void> => {
+${functionName}: ({
+  ${functionParameters.map((param) => param.parameter).join(', \n  ')}
+}: {
+  ${functionParameters.map((param) => param.parameterType).join(', \n  ')}
+}): Promise<void> => {
   return new Promise<void>(async (resolve, reject) => {
     try {
       ${publishOperation}

--- a/src/codegen/generators/typescript/channels/protocols/nats/corePublish.ts
+++ b/src/codegen/generators/typescript/channels/protocols/nats/corePublish.ts
@@ -29,28 +29,33 @@ nc.publish(${addressToUse}, dataToSend, options);`;
 
   const functionParameters = [
     {
-      parameter: `message: ${messageType}`,
+      parameter: `message`,
+      parameterType: `message: ${messageType}`,
       jsDoc: ' * @param message to publish'
     },
     ...(channelParameters
       ? [
           {
-            parameter: `parameters: ${channelParameters.type}`,
+            parameter: `parameters`,
+            parameterType: `parameters: ${channelParameters.type}`,
             jsDoc: ' * @param parameters for topic substitution'
           }
         ]
       : []),
     {
-      parameter: 'nc: Nats.NatsConnection',
+      parameter: 'nc',
+      parameterType: 'nc: Nats.NatsConnection',
       jsDoc: ' * @param nc the NATS client to publish from'
     },
     {
-      parameter: 'codec: any = Nats.JSONCodec()',
+      parameter: 'codec = Nats.JSONCodec()',
+      parameterType: 'codec?: Nats.Codec<any>',
       jsDoc:
         ' * @param codec the serialization codec to use while transmitting the message'
     },
     {
-      parameter: 'options?: Nats.PublishOptions',
+      parameter: 'options',
+      parameterType: 'options?: Nats.PublishOptions',
       jsDoc: ' * @param options to use while publishing the message'
     }
   ];
@@ -60,9 +65,11 @@ nc.publish(${addressToUse}, dataToSend, options);`;
  * 
  ${functionParameters.map((param) => param.jsDoc).join('\n')}
  */
-${functionName}: (
-  ${functionParameters.map((param) => param.parameter).join(', ')}
-): Promise<void> => {
+${functionName}: ({
+  ${functionParameters.map((param) => param.parameter).join(', \n  ')}
+}: {
+  ${functionParameters.map((param) => param.parameterType).join(', \n  ')}
+}): Promise<void> => {
   return new Promise<void>(async (resolve, reject) => {
     try {
       ${publishOperation}

--- a/src/codegen/generators/typescript/channels/protocols/nats/coreReply.ts
+++ b/src/codegen/generators/typescript/channels/protocols/nats/coreReply.ts
@@ -57,32 +57,38 @@ export function renderCoreReply({
 
   const functionParameters = [
     {
-      parameter: `onDataCallback: (${callbackFunctionParameters.map((param) => param.parameter).join(', ')}) => ${replyType} | Promise<${replyType}>`,
+      parameter: `onDataCallback`,
+      parameterType: `onDataCallback: (${callbackFunctionParameters.map((param) => param.parameter).join(', ')}) => ${replyType} | Promise<${replyType}>`,
       jsDoc: ` * @param {${functionName}Callback} onDataCallback to call when the request is received`
     },
     ...(channelParameters
       ? [
           {
-            parameter: `parameters: ${channelParameters.type}`,
+            parameter: `parameters`,
+            parameterType: `parameters: ${channelParameters.type}`,
             jsDoc: ' * @param parameters for topic substitution'
           }
         ]
       : []),
     {
-      parameter: 'nc: Nats.NatsConnection',
+      parameter: 'nc',
+      parameterType: 'nc: Nats.NatsConnection',
       jsDoc: ' * @param nc the nats client to setup the reply for'
     },
     {
-      parameter: 'codec: any = Nats.JSONCodec()',
+      parameter: 'codec = Nats.JSONCodec()',
+      parameterType: 'codec?: Nats.Codec<any>',
       jsDoc:
-        ' * @param codec the serialization codec to use when receiving and transmitting reply'
+        ' * @param codec the serialization codec to use when receiving request and transmitting reply'
     },
     {
-      parameter: 'options?: Nats.SubscriptionOptions',
+      parameter: 'options',
+      parameterType: 'options?: Nats.SubscriptionOptions',
       jsDoc: ' * @param options when setting up the reply'
     },
     {
-      parameter: 'skipMessageValidation: boolean = false',
+      parameter: 'skipMessageValidation = false',
+      parameterType: 'skipMessageValidation?: boolean',
       jsDoc:
         ' * @param skipMessageValidation turn off runtime validation of incoming messages'
     }
@@ -115,9 +121,11 @@ msg.respond(dataToSend);`;
  * 
  ${jsDocParameters}
  */
-${functionName}: (
+${functionName}: ({
   ${functionParameters.map((param) => param.parameter).join(', \n  ')}
-): Promise<Nats.Subscription> => {
+}: {
+  ${functionParameters.map((param) => param.parameterType).join(', \n  ')}
+}): Promise<Nats.Subscription> => {
   return new Promise(async (resolve, reject) => {
     try {
       let subscription = nc.subscribe(${addressToUse}, options);

--- a/src/codegen/generators/typescript/channels/protocols/nats/coreRequest.ts
+++ b/src/codegen/generators/typescript/channels/protocols/nats/coreRequest.ts
@@ -38,34 +38,40 @@ export function renderCoreRequest({
 
   const functionParameters = [
     {
-      parameter: `requestMessage: ${requestType}`,
+      parameter: `requestMessage`,
+      parameterType: `requestMessage: ${requestType}`,
       jsDoc: ` * @param requestMessage the message to send`
     },
     ...(channelParameters
       ? [
           {
-            parameter: `parameters: ${channelParameters.type}`,
+            parameter: `parameters`,
+            parameterType: `parameters: ${channelParameters.type}`,
             jsDoc: ' * @param parameters for topic substitution'
           }
         ]
       : []),
     {
-      parameter: 'nc: Nats.NatsConnection',
-      jsDoc: ' * @param nc the NATS client to send the request through'
+      parameter: 'nc',
+      parameterType: 'nc: Nats.NatsConnection',
+      jsDoc: ' * @param nc the nats client to setup the request for'
     },
     {
-      parameter: 'codec: any = Nats.JSONCodec()',
+      parameter: 'codec = Nats.JSONCodec()',
+      parameterType: 'codec?: Nats.Codec<any>',
       jsDoc:
-        ' * @param codec the serialization codec to use when sending and receiving the message'
+        ' * @param codec the serialization codec to use when transmitting request and receiving reply'
     },
     {
-      parameter: 'options?: Nats.RequestOptions',
+      parameter: 'options',
+      parameterType: 'options?: Nats.RequestOptions',
       jsDoc: ' * @param options when sending the request'
     },
     {
-      parameter: 'skipMessageValidation: boolean = false',
+      parameter: 'skipMessageValidation = false',
+      parameterType: 'skipMessageValidation?: boolean',
       jsDoc:
-        ' * @param skipMessageValidation turn off runtime validation of outgoing messages'
+        ' * @param skipMessageValidation turn off runtime validation of incoming messages'
     }
   ];
 
@@ -78,9 +84,11 @@ export function renderCoreRequest({
  * 
  ${jsDocParameters}
  */
-${functionName}: (
+${functionName}: ({
   ${functionParameters.map((param) => param.parameter).join(', \n  ')}
-): Promise<${replyType}> => {
+}: {
+  ${functionParameters.map((param) => param.parameterType).join(', \n  ')}
+}): Promise<${replyType}> => {
   return new Promise(async (resolve, reject) => {
     try {
       ${potentialValidatorCreation}

--- a/src/codegen/generators/typescript/channels/protocols/nats/coreSubscribe.ts
+++ b/src/codegen/generators/typescript/channels/protocols/nats/coreSubscribe.ts
@@ -61,32 +61,38 @@ export function renderCoreSubscribe({
 
   const functionParameters = [
     {
-      parameter: `onDataCallback: (${callbackFunctionParameters.map((param) => param.parameter).join(', ')}) => void`,
+      parameter: `onDataCallback`,
+      parameterType: `onDataCallback: (${callbackFunctionParameters.map((param) => param.parameter).join(', ')}) => void`,
       jsDoc: ` * @param {${functionName}Callback} onDataCallback to call when messages are received`
     },
     ...(channelParameters
       ? [
           {
-            parameter: `parameters: ${channelParameters.type}`,
+            parameter: `parameters`,
+            parameterType: `parameters: ${channelParameters.type}`,
             jsDoc: ' * @param parameters for topic substitution'
           }
         ]
       : []),
     {
-      parameter: 'nc: Nats.NatsConnection',
-      jsDoc: ' * @param nc the NATS client to subscribe through'
+      parameter: 'nc',
+      parameterType: 'nc: Nats.NatsConnection',
+      jsDoc: ' * @param nc the nats client to setup the subscribe for'
     },
     {
-      parameter: 'codec: any = Nats.JSONCodec()',
+      parameter: 'codec = Nats.JSONCodec()',
+      parameterType: 'codec?: Nats.Codec<any>',
       jsDoc:
         ' * @param codec the serialization codec to use while receiving the message'
     },
     {
-      parameter: 'options?: Nats.SubscriptionOptions',
+      parameter: 'options',
+      parameterType: 'options?: Nats.SubscriptionOptions',
       jsDoc: ' * @param options when setting up the subscription'
     },
     {
-      parameter: 'skipMessageValidation: boolean = false',
+      parameter: 'skipMessageValidation = false',
+      parameterType: 'skipMessageValidation?: boolean',
       jsDoc:
         ' * @param skipMessageValidation turn off runtime validation of incoming messages'
     }
@@ -126,9 +132,11 @@ ${callbackJsDocParameters}
  * 
 ${jsDocParameters}
  */
-${functionName}: (
+${functionName}: ({
   ${functionParameters.map((param) => param.parameter).join(', \n  ')}
-): Promise<Nats.Subscription> => {
+}: {
+  ${functionParameters.map((param) => param.parameterType).join(', \n  ')}
+}): Promise<Nats.Subscription> => {
   return new Promise(async (resolve, reject) => {
     try {
       const subscription = nc.subscribe(${addressToUse}, options);

--- a/src/codegen/generators/typescript/channels/protocols/nats/jetstreamPublish.ts
+++ b/src/codegen/generators/typescript/channels/protocols/nats/jetstreamPublish.ts
@@ -29,28 +29,33 @@ await js.publish(${addressToUse}, dataToSend, options);`;
 
   const functionParameters = [
     {
-      parameter: `message: ${messageType}`,
+      parameter: `message`,
+      parameterType: `message: ${messageType}`,
       jsDoc: ' * @param message to publish over jetstream'
     },
     ...(channelParameters
       ? [
           {
-            parameter: `parameters: ${channelParameters.type}`,
+            parameter: `parameters`,
+            parameterType: `parameters: ${channelParameters.type}`,
             jsDoc: ' * @param parameters for topic substitution'
           }
         ]
       : []),
     {
-      parameter: 'js: Nats.JetStreamClient',
+      parameter: 'js',
+      parameterType: 'js: Nats.JetStreamClient',
       jsDoc: ' * @param js the JetStream client to publish from'
     },
     {
-      parameter: 'codec: any = Nats.JSONCodec()',
+      parameter: 'codec = Nats.JSONCodec()',
+      parameterType: 'codec?: Nats.Codec<any>',
       jsDoc:
         ' * @param codec the serialization codec to use while transmitting the message'
     },
     {
-      parameter: 'options: Partial<Nats.JetStreamPublishOptions> = {}',
+      parameter: 'options = {}',
+      parameterType: 'options?: Partial<Nats.JetStreamPublishOptions>',
       jsDoc: ' * @param options to use while publishing the message'
     }
   ];
@@ -60,9 +65,11 @@ await js.publish(${addressToUse}, dataToSend, options);`;
  * 
  ${functionParameters.map((param) => param.jsDoc).join('\n')}
  */
-${functionName}: (
+${functionName}: ({
   ${functionParameters.map((param) => param.parameter).join(', \n  ')}
-): Promise<void> => {
+}: {
+  ${functionParameters.map((param) => param.parameterType).join(', \n  ')}
+}): Promise<void> => {
   return new Promise<void>(async (resolve, reject) => {
     try {
       ${publishOperation}

--- a/src/codegen/generators/typescript/channels/protocols/nats/jetstreamPullSubscribe.ts
+++ b/src/codegen/generators/typescript/channels/protocols/nats/jetstreamPullSubscribe.ts
@@ -57,33 +57,39 @@ export function renderJetstreamPullSubscribe({
 
   const functionParameters = [
     {
-      parameter: `onDataCallback: (${callbackFunctionParameters.map((param) => param.parameter).join(', ')}) => void`,
+      parameter: `onDataCallback`,
+      parameterType: `onDataCallback: (${callbackFunctionParameters.map((param) => param.parameter).join(', ')}) => void`,
       jsDoc: ` * @param {${functionName}Callback} onDataCallback to call when messages are received`
     },
     ...(channelParameters
       ? [
           {
-            parameter: `parameters: ${channelParameters.type}`,
+            parameter: `parameters`,
+            parameterType: `parameters: ${channelParameters.type}`,
             jsDoc: ' * @param parameters for topic substitution'
           }
         ]
       : []),
     {
-      parameter: 'js: Nats.JetStreamClient',
+      parameter: 'js',
+      parameterType: 'js: Nats.JetStreamClient',
       jsDoc: ' * @param js the JetStream client to pull subscribe through'
     },
     {
-      parameter:
+      parameter: 'options',
+      parameterType:
         'options: Nats.ConsumerOptsBuilder | Partial<Nats.ConsumerOpts>',
       jsDoc: ' * @param options when setting up the subscription'
     },
     {
-      parameter: 'codec: any = Nats.JSONCodec()',
+      parameter: 'codec = Nats.JSONCodec()',
+      parameterType: 'codec?: Nats.Codec<any>',
       jsDoc:
-        ' * @param codec the serialization codec to use while receiving the message'
+        ' * @param codec the serialization codec to use while transmitting the message'
     },
     {
-      parameter: 'skipMessageValidation: boolean = false',
+      parameter: 'skipMessageValidation = false',
+      parameterType: 'skipMessageValidation?: boolean',
       jsDoc:
         ' * @param skipMessageValidation turn off runtime validation of incoming messages'
     }
@@ -120,9 +126,11 @@ onDataCallback(undefined, ${messageUnmarshalling}, msg);`;
  * 
  ${jsDocParameters}
  */
-${functionName}: (
+${functionName}: ({
   ${functionParameters.map((param) => param.parameter).join(', \n  ')}
-): Promise<Nats.JetStreamPullSubscription> => {
+}: {
+  ${functionParameters.map((param) => param.parameterType).join(', \n  ')}
+}): Promise<Nats.JetStreamPullSubscription> => {
   return new Promise(async (resolve, reject) => {
     try {
       const subscription = await js.pullSubscribe(${addressToUse}, options);

--- a/src/codegen/generators/typescript/channels/protocols/nats/jetstreamPushSubscription.ts
+++ b/src/codegen/generators/typescript/channels/protocols/nats/jetstreamPushSubscription.ts
@@ -60,33 +60,39 @@ export function renderJetstreamPushSubscription({
 
   const functionParameters = [
     {
-      parameter: `onDataCallback: (${callbackFunctionParameters.map((param) => param.parameter).join(', ')}) => void`,
+      parameter: `onDataCallback`,
+      parameterType: `onDataCallback: (${callbackFunctionParameters.map((param) => param.parameter).join(', ')}) => void`,
       jsDoc: ` * @param {${functionName}Callback} onDataCallback to call when messages are received`
     },
     ...(channelParameters
       ? [
           {
-            parameter: `parameters: ${channelParameters.type}`,
+            parameter: `parameters`,
+            parameterType: `parameters: ${channelParameters.type}`,
             jsDoc: ' * @param parameters for topic substitution'
           }
         ]
       : []),
     {
-      parameter: 'js: Nats.JetStreamClient',
+      parameter: 'js',
+      parameterType: 'js: Nats.JetStreamClient',
       jsDoc: ' * @param js the JetStream client to pull subscribe through'
     },
     {
-      parameter:
+      parameter: 'options',
+      parameterType:
         'options: Nats.ConsumerOptsBuilder | Partial<Nats.ConsumerOpts>',
       jsDoc: ' * @param options when setting up the subscription'
     },
     {
-      parameter: 'codec: any = Nats.JSONCodec()',
+      parameter: 'codec = Nats.JSONCodec()',
+      parameterType: 'codec?: Nats.Codec<any>',
       jsDoc:
-        ' * @param codec the serialization codec to use while receiving the message'
+        ' * @param codec the serialization codec to use while transmitting the message'
     },
     {
-      parameter: 'skipMessageValidation: boolean = false',
+      parameter: 'skipMessageValidation = false',
+      parameterType: 'skipMessageValidation?: boolean',
       jsDoc:
         ' * @param skipMessageValidation turn off runtime validation of incoming messages'
     }
@@ -123,9 +129,11 @@ onDataCallback(undefined, ${messageUnmarshalling}, msg);`;
  * 
  ${jsDocParameters}
  */
-${functionName}: (
+${functionName}: ({
   ${functionParameters.map((param) => param.parameter).join(', \n  ')}
-): Promise<Nats.JetStreamSubscription> => {
+}: {
+  ${functionParameters.map((param) => param.parameterType).join(', \n  ')}
+}): Promise<Nats.JetStreamSubscription> => {
   return new Promise(async (resolve, reject) => {
     try {
       const subscription = await js.subscribe(${addressToUse}, options);

--- a/src/codegen/generators/typescript/client/protocols/nats.ts
+++ b/src/codegen/generators/typescript/client/protocols/nats.ts
@@ -140,7 +140,7 @@ export class NatsClient {
    * @param userCreds to use
    * @param options to connect with
    */
-  async connectWithUserCreds(userCreds: string, options ? : Nats.ConnectionOptions, codec ? : Nats.Codec < any > ) {
+  async connectWithUserCreds(userCreds: string, options?: Nats.ConnectionOptions, codec?: Nats.Codec<any> ) {
     return await this.connect({
       user: userCreds,
       ...options
@@ -153,7 +153,7 @@ export class NatsClient {
    * @param pass password to use
    * @param options to connect with
    */
-  async connectWithUserPass(user: string, pass: string, options ? : Nats.ConnectionOptions, codec ? : Nats.Codec < any > ) {
+  async connectWithUserPass(user: string, pass: string, options?: Nats.ConnectionOptions, codec?: Nats.Codec<any> ) {
     return await this.connect({
       user: user,
       pass: pass,
@@ -166,7 +166,7 @@ export class NatsClient {
     * @param host to connect to
     * @param options to connect with
     */
-  async connectToHost(host: string, options ? : Nats.ConnectionOptions, codec ? : Nats.Codec < any > ) {
+  async connectToHost(host: string, options?: Nats.ConnectionOptions, codec?: Nats.Codec<any> ) {
     return await this.connect({
       servers: [host],
       ...options

--- a/src/codegen/generators/typescript/client/protocols/nats/corePublish.ts
+++ b/src/codegen/generators/typescript/client/protocols/nats/corePublish.ts
@@ -18,7 +18,7 @@ export function renderCorePublish({
     ...(channelParameterType
       ? [
           {
-            parameter: `parameters: ${channelParameterType}`,
+            parameter: `parameters`,
             parameterType: `parameters: ${channelParameterType}`,
             jsDoc: ' * @param parameters for topic substitution'
           }

--- a/src/codegen/generators/typescript/client/protocols/nats/corePublish.ts
+++ b/src/codegen/generators/typescript/client/protocols/nats/corePublish.ts
@@ -19,32 +19,35 @@ export function renderCorePublish({
       ? [
           {
             parameter: `parameters: ${channelParameterType}`,
+            parameterType: `parameters: ${channelParameterType}`,
             jsDoc: ' * @param parameters for topic substitution'
           }
         ]
       : []),
     {
-      parameter: 'options?: Nats.PublishOptions',
+      parameter: 'options',
+      parameterType: 'options?: Nats.PublishOptions',
       jsDoc: ' * @param options to use while publishing the message'
     }
   ];
 
-  const functionCallParameters = [
-    'message',
-    ...(channelParameterType ? ['parameters'] : []),
-    'nc: this.nc',
-    'codec: this.codec',
-    'options'
-  ];
   return `
   /**
    * ${description}
    * 
-  ${functionParameters.map((param) => param.jsDoc).join('\n')}
+  ${functionParameters.map((param) => param.jsDoc).join('\n  ')}
    */
-  public async ${channelName}(${functionParameters.map((param) => param.parameter).join(', ')}): Promise<void> {
+  public async ${channelName}({
+    ${functionParameters.map((param) => param.parameter).join(', \n    ')}
+  }: {
+    ${functionParameters.map((param) => param.parameterType).join(', \n    ')}
+  }): Promise<void> {
     if (!this.isClosed() && this.nc !== undefined && this.codec !== undefined) {
-      await nats.${channelName}({${functionCallParameters.join(', ')}});
+      await nats.${channelName}({
+        nc: this.nc,
+        codec: this.codec,
+        ${functionParameters.map((param) => param.parameter).join(', \n        ')}
+      });
     } else {
       Promise.reject('Nats client not available yet, please connect or set the client');
     }

--- a/src/codegen/generators/typescript/client/protocols/nats/corePublish.ts
+++ b/src/codegen/generators/typescript/client/protocols/nats/corePublish.ts
@@ -11,7 +11,8 @@ export function renderCorePublish({
 }) {
   const functionParameters = [
     {
-      parameter: `message: ${messageType}`,
+      parameter: `message`,
+      parameterType: `message: ${messageType}`,
       jsDoc: ' * @param message to publish'
     },
     ...(channelParameterType
@@ -31,8 +32,8 @@ export function renderCorePublish({
   const functionCallParameters = [
     'message',
     ...(channelParameterType ? ['parameters'] : []),
-    'this.nc',
-    'this.codec',
+    'nc: this.nc',
+    'codec: this.codec',
     'options'
   ];
   return `
@@ -43,7 +44,7 @@ export function renderCorePublish({
    */
   public async ${channelName}(${functionParameters.map((param) => param.parameter).join(', ')}): Promise<void> {
     if (!this.isClosed() && this.nc !== undefined && this.codec !== undefined) {
-      await nats.${channelName}(${functionCallParameters.join(', ')});
+      await nats.${channelName}({${functionCallParameters.join(', ')}});
     } else {
       Promise.reject('Nats client not available yet, please connect or set the client');
     }

--- a/src/codegen/generators/typescript/client/protocols/nats/corePublish.ts
+++ b/src/codegen/generators/typescript/client/protocols/nats/corePublish.ts
@@ -31,6 +31,13 @@ export function renderCorePublish({
     }
   ];
 
+  const functionCallParameters = [
+    'message',
+    ...(channelParameterType ? ['parameters'] : []),
+    'nc: this.nc',
+    'codec: this.codec',
+    'options'
+  ];
   return `
   /**
    * ${description}
@@ -44,9 +51,7 @@ export function renderCorePublish({
   }): Promise<void> {
     if (!this.isClosed() && this.nc !== undefined && this.codec !== undefined) {
       await nats.${channelName}({
-        nc: this.nc,
-        codec: this.codec,
-        ${functionParameters.map((param) => param.parameter).join(', \n        ')}
+        ${functionCallParameters.join(', \n        ')}
       });
     } else {
       Promise.reject('Nats client not available yet, please connect or set the client');

--- a/src/codegen/generators/typescript/client/protocols/nats/coreSubscribe.ts
+++ b/src/codegen/generators/typescript/client/protocols/nats/coreSubscribe.ts
@@ -58,8 +58,8 @@ export function renderCoreSubscribe({
   const functionCallParameters = [
     'onDataCallback',
     ...(channelParameterType ? ['parameters'] : []),
-    'this.nc',
-    'this.codec',
+    'nc: this.nc',
+    'codec: this.codec',
     'options'
   ];
   return `
@@ -72,7 +72,7 @@ public ${channelName}(${functionParameters.map((param) => param.parameter).join(
   return new Promise(async (resolve, reject) => {
     if(!this.isClosed() && this.nc !== undefined && this.codec !== undefined){
       try {
-        const sub = await nats.${channelName}(${functionCallParameters.join(',')});
+        const sub = await nats.${channelName}({${functionCallParameters.join(',')}});
         if(flush){
           await this.nc.flush();
         }

--- a/src/codegen/generators/typescript/client/protocols/nats/coreSubscribe.ts
+++ b/src/codegen/generators/typescript/client/protocols/nats/coreSubscribe.ts
@@ -81,9 +81,7 @@ export function renderCoreSubscribe({
     if(!this.isClosed() && this.nc !== undefined && this.codec !== undefined){
       try {
         const sub = await nats.${channelName}({
-          nc: this.nc,
-          codec: this.codec,
-          ${functionParameters.map((param) => param.parameter).join(', \n          ')}
+          ${functionCallParameters.join(', \n          ')}
         });
         if(flush){
           await this.nc.flush();

--- a/src/codegen/generators/typescript/client/protocols/nats/coreSubscribe.ts
+++ b/src/codegen/generators/typescript/client/protocols/nats/coreSubscribe.ts
@@ -34,23 +34,27 @@ export function renderCoreSubscribe({
 
   const functionParameters = [
     {
-      parameter: `onDataCallback: (${callbackFunctionParameters.map((param) => param.parameter).join(', ')}) => void`,
+      parameter: `onDataCallback`,
+      parameterType: `onDataCallback: (${callbackFunctionParameters.map((param) => param.parameter).join(', ')}) => void`,
       jsDoc: ` * @param {${channelName}Callback} onDataCallback to call when messages are received`
     },
     ...(channelParameterType
       ? [
           {
-            parameter: `parameters: ${channelParameterType}`,
+            parameter: `parameters`,
+            parameterType: `parameters: ${channelParameterType}`,
             jsDoc: ' * @param parameters for topic substitution'
           }
         ]
       : []),
     {
-      parameter: 'options?: Nats.SubscriptionOptions',
+      parameter: 'options',
+      parameterType: 'options?: Nats.SubscriptionOptions',
       jsDoc: ' * @param options when setting up the subscription'
     },
     {
-      parameter: 'flush?: boolean',
+      parameter: 'flush',
+      parameterType: 'flush?: boolean',
       jsDoc: ' * @param options when setting up the subscription'
     }
   ];
@@ -63,16 +67,24 @@ export function renderCoreSubscribe({
     'options'
   ];
   return `
-/** 
-  * ${description}
-  * 
-  ${functionParameters.map((param) => param.jsDoc).join('\n')}
-  */
-public ${channelName}(${functionParameters.map((param) => param.parameter).join(', ')}): Promise<Nats.Subscription> {
+  /** 
+   * ${description}
+   * 
+   ${functionParameters.map((param) => param.jsDoc).join('\n   ')}
+   */
+  public ${channelName}({
+    ${functionParameters.map((param) => param.parameter).join(', \n    ')}
+  }: {
+    ${functionParameters.map((param) => param.parameterType).join(', \n    ')}
+  }): Promise<Nats.Subscription> {
   return new Promise(async (resolve, reject) => {
     if(!this.isClosed() && this.nc !== undefined && this.codec !== undefined){
       try {
-        const sub = await nats.${channelName}({${functionCallParameters.join(',')}});
+        const sub = await nats.${channelName}({
+          nc: this.nc,
+          codec: this.codec,
+          ${functionParameters.map((param) => param.parameter).join(', \n          ')}
+        });
         if(flush){
           await this.nc.flush();
         }

--- a/src/codegen/generators/typescript/client/protocols/nats/jetStreamPullSubscription.ts
+++ b/src/codegen/generators/typescript/client/protocols/nats/jetStreamPullSubscription.ts
@@ -34,42 +34,46 @@ export function renderJetStreamPullSubscription({
 
   const functionParameters = [
     {
-      parameter: `onDataCallback: (${callbackFunctionParameters.map((param) => param.parameter).join(', ')}) => void`,
+      parameter: `onDataCallback`,
+      parameterType: `onDataCallback: (${callbackFunctionParameters.map((param) => param.parameter).join(', ')}) => void`,
       jsDoc: ` * @param {${channelName}Callback} onDataCallback to call when messages are received`
     },
     ...(channelParameterType
       ? [
           {
-            parameter: `parameters: ${channelParameterType}`,
+            parameter: `parameters`,
+            parameterType: `parameters: ${channelParameterType}`,
             jsDoc: ' * @param parameters for topic substitution'
           }
         ]
       : []),
     {
-      parameter:
+      parameter: 'options',
+      parameterType:
         'options: Nats.ConsumerOptsBuilder | Partial<Nats.ConsumerOpts>',
       jsDoc: ' * @param options when setting up the subscription'
     }
   ];
 
-  const functionCallParameters = [
-    'onDataCallback',
-    ...(channelParameterType ? ['parameters'] : []),
-    'js: this.js',
-    'options',
-    'codec: this.codec'
-  ];
   return `
   /**
   * ${description}
   * 
-  ${functionParameters.map((param) => param.jsDoc).join('\n')}
+  ${functionParameters.map((param) => param.jsDoc).join('\n  ')}
   */
-  public ${channelName}(${functionParameters.map((param) => param.parameter).join(', ')}): Promise<Nats.JetStreamPullSubscription> {
+  public ${channelName}({
+    ${functionParameters.map((param) => param.parameter).join(', \n    ')}
+  }: {
+    ${functionParameters.map((param) => param.parameterType).join(', \n    ')}
+  }): Promise<Nats.JetStreamPullSubscription> {
       return new Promise(async (resolve, reject) => {
         if (!this.isClosed() && this.nc !== undefined && this.codec !== undefined && this.js !== undefined) {
           try {
-            const sub = await nats.${channelName}({${functionCallParameters.join(', ')}});
+            const sub = await nats.${channelName}({
+              js: this.js,
+              codec: this.codec,
+              ${functionParameters.map((param) => param.parameter).join(', \n              ')}
+            });
             resolve(sub);
           } catch (e: any) {
             reject(e);

--- a/src/codegen/generators/typescript/client/protocols/nats/jetStreamPullSubscription.ts
+++ b/src/codegen/generators/typescript/client/protocols/nats/jetStreamPullSubscription.ts
@@ -55,6 +55,13 @@ export function renderJetStreamPullSubscription({
     }
   ];
 
+  const functionCallParameters = [
+    'onDataCallback',
+    ...(channelParameterType ? ['parameters'] : []),
+    'js: this.js',
+    'codec: this.codec',
+    'options'
+  ];
   return `
   /**
   * ${description}
@@ -70,9 +77,7 @@ export function renderJetStreamPullSubscription({
         if (!this.isClosed() && this.nc !== undefined && this.codec !== undefined && this.js !== undefined) {
           try {
             const sub = await nats.${channelName}({
-              js: this.js,
-              codec: this.codec,
-              ${functionParameters.map((param) => param.parameter).join(', \n              ')}
+              ${functionCallParameters.join(', \n              ')}
             });
             resolve(sub);
           } catch (e: any) {

--- a/src/codegen/generators/typescript/client/protocols/nats/jetStreamPullSubscription.ts
+++ b/src/codegen/generators/typescript/client/protocols/nats/jetStreamPullSubscription.ts
@@ -50,7 +50,7 @@ export function renderJetStreamPullSubscription({
     {
       parameter: 'options',
       parameterType:
-        'options: Nats.ConsumerOptsBuilder | Partial<Nats.ConsumerOpts>',
+        'options?: Nats.ConsumerOptsBuilder | Partial<Nats.ConsumerOpts>',
       jsDoc: ' * @param options when setting up the subscription'
     }
   ];

--- a/src/codegen/generators/typescript/client/protocols/nats/jetStreamPullSubscription.ts
+++ b/src/codegen/generators/typescript/client/protocols/nats/jetStreamPullSubscription.ts
@@ -48,9 +48,9 @@ export function renderJetStreamPullSubscription({
         ]
       : []),
     {
-      parameter: 'options',
+      parameter: 'options = {}',
       parameterType:
-        'options?: Nats.ConsumerOptsBuilder | Partial<Nats.ConsumerOpts>',
+        'options: Nats.ConsumerOptsBuilder | Partial<Nats.ConsumerOpts>',
       jsDoc: ' * @param options when setting up the subscription'
     }
   ];

--- a/src/codegen/generators/typescript/client/protocols/nats/jetStreamPullSubscription.ts
+++ b/src/codegen/generators/typescript/client/protocols/nats/jetStreamPullSubscription.ts
@@ -55,9 +55,9 @@ export function renderJetStreamPullSubscription({
   const functionCallParameters = [
     'onDataCallback',
     ...(channelParameterType ? ['parameters'] : []),
-    'this.js',
+    'js: this.js',
     'options',
-    'this.codec'
+    'codec: this.codec'
   ];
   return `
   /**
@@ -69,7 +69,7 @@ export function renderJetStreamPullSubscription({
       return new Promise(async (resolve, reject) => {
         if (!this.isClosed() && this.nc !== undefined && this.codec !== undefined && this.js !== undefined) {
           try {
-            const sub = await nats.${channelName}(${functionCallParameters.join(', ')});
+            const sub = await nats.${channelName}({${functionCallParameters.join(', ')}});
             resolve(sub);
           } catch (e: any) {
             reject(e);

--- a/src/codegen/generators/typescript/client/protocols/nats/jetstreamPublish.ts
+++ b/src/codegen/generators/typescript/client/protocols/nats/jetstreamPublish.ts
@@ -26,7 +26,7 @@ export function renderJetStreamPublish({
       : []),
     {
       parameter: 'options = {}',
-      parameterType: 'options: Partial<Nats.JetStreamPublishOptions>',
+      parameterType: 'options?: Partial<Nats.JetStreamPublishOptions>',
       jsDoc: ' * @param options to use while publishing the message'
     }
   ];

--- a/src/codegen/generators/typescript/client/protocols/nats/jetstreamPublish.ts
+++ b/src/codegen/generators/typescript/client/protocols/nats/jetstreamPublish.ts
@@ -30,6 +30,13 @@ export function renderJetStreamPublish({
       jsDoc: ' * @param options to use while publishing the message'
     }
   ];
+  const functionCallParameters = [
+    'message',
+    ...(channelParameterType ? ['parameters'] : []),
+    'nc: this.nc',
+    'codec: this.codec',
+    'options'
+  ];
 
   return `
   /**
@@ -44,9 +51,7 @@ export function renderJetStreamPublish({
   }): Promise<void> {
     if (!this.isClosed() && this.nc !== undefined && this.codec !== undefined && this.js !== undefined) {
       return nats.${channelName}({
-        js: this.js,
-        codec: this.codec,
-        ${functionParameters.map((param) => param.parameter).join(', \n        ')}
+        ${functionCallParameters.join(', \n        ')}
       });
     } else {
       Promise.reject('Nats client not available yet, please connect or set the client');

--- a/src/codegen/generators/typescript/client/protocols/nats/jetstreamPublish.ts
+++ b/src/codegen/generators/typescript/client/protocols/nats/jetstreamPublish.ts
@@ -18,35 +18,36 @@ export function renderJetStreamPublish({
     ...(channelParameterType
       ? [
           {
-            parameter: `parameters: ${channelParameterType}`,
+            parameter: `parameters`,
+            parameterType: `parameters: ${channelParameterType}`,
             jsDoc: ' * @param parameters for topic substitution'
           }
         ]
       : []),
     {
-      parameter: 'options: Partial<Nats.JetStreamPublishOptions> = {}',
+      parameter: 'options = {}',
+      parameterType: 'options: Partial<Nats.JetStreamPublishOptions>',
       jsDoc: ' * @param options to use while publishing the message'
     }
   ];
 
-  const functionCallParameters = [
-    'message',
-    ...(channelParameterType ? ['parameters'] : []),
-    'js: this.js',
-    'codec: this.codec',
-    'options'
-  ];
   return `
   /**
    * ${description}
    * 
   ${functionParameters.map((param) => param.jsDoc).join('\n')}
    */
-  public async ${channelName}(
-    ${functionParameters.map((param) => param.parameter).join(', ')}
-  ): Promise<void> {
+  public async ${channelName}({
+    ${functionParameters.map((param) => param.parameter).join(', \n    ')}
+  }: {
+    ${functionParameters.map((param) => param.parameterType).join(', \n    ')}
+  }): Promise<void> {
     if (!this.isClosed() && this.nc !== undefined && this.codec !== undefined && this.js !== undefined) {
-      return nats.${channelName}({${functionCallParameters.join(', ')}});
+      return nats.${channelName}({
+        js: this.js,
+        codec: this.codec,
+        ${functionParameters.map((param) => param.parameter).join(', \n        ')}
+      });
     } else {
       Promise.reject('Nats client not available yet, please connect or set the client');
     }

--- a/src/codegen/generators/typescript/client/protocols/nats/jetstreamPublish.ts
+++ b/src/codegen/generators/typescript/client/protocols/nats/jetstreamPublish.ts
@@ -11,7 +11,8 @@ export function renderJetStreamPublish({
 }) {
   const functionParameters = [
     {
-      parameter: `message: ${messageType}`,
+      parameter: `message`,
+      parameterType: `message: ${messageType}`,
       jsDoc: ' * @param message to publish'
     },
     ...(channelParameterType
@@ -31,8 +32,8 @@ export function renderJetStreamPublish({
   const functionCallParameters = [
     'message',
     ...(channelParameterType ? ['parameters'] : []),
-    'this.js',
-    'this.codec',
+    'js: this.js',
+    'codec: this.codec',
     'options'
   ];
   return `
@@ -45,7 +46,7 @@ export function renderJetStreamPublish({
     ${functionParameters.map((param) => param.parameter).join(', ')}
   ): Promise<void> {
     if (!this.isClosed() && this.nc !== undefined && this.codec !== undefined && this.js !== undefined) {
-      return nats.${channelName}(${functionCallParameters.join(', ')});
+      return nats.${channelName}({${functionCallParameters.join(', ')}});
     } else {
       Promise.reject('Nats client not available yet, please connect or set the client');
     }

--- a/src/codegen/generators/typescript/client/protocols/nats/jetstreamPublish.ts
+++ b/src/codegen/generators/typescript/client/protocols/nats/jetstreamPublish.ts
@@ -33,7 +33,7 @@ export function renderJetStreamPublish({
   const functionCallParameters = [
     'message',
     ...(channelParameterType ? ['parameters'] : []),
-    'nc: this.nc',
+    'js: this.js',
     'codec: this.codec',
     'options'
   ];

--- a/src/codegen/generators/typescript/client/protocols/nats/jetstreamPushSubscription.ts
+++ b/src/codegen/generators/typescript/client/protocols/nats/jetstreamPushSubscription.ts
@@ -34,42 +34,46 @@ export function renderJetStreamPushSubscription({
 
   const functionParameters = [
     {
-      parameter: `onDataCallback: (${callbackFunctionParameters.map((param) => param.parameter).join(', ')}) => void`,
+      parameter: `onDataCallback`,
+      parameterType: `onDataCallback: (${callbackFunctionParameters.map((param) => param.parameter).join(', ')}) => void`,
       jsDoc: ` * @param {${channelName}Callback} onDataCallback to call when messages are received`
     },
     ...(channelParameterType
       ? [
           {
-            parameter: `parameters: ${channelParameterType}`,
+            parameter: `parameters`,
+            parameterType: `parameters: ${channelParameterType}`,
             jsDoc: ' * @param parameters for topic substitution'
           }
         ]
       : []),
     {
-      parameter:
+      parameter: 'options',
+      parameterType:
         'options: Nats.ConsumerOptsBuilder | Partial<Nats.ConsumerOpts>',
       jsDoc: ' * @param options when setting up the subscription'
     }
   ];
 
-  const functionCallParameters = [
-    'onDataCallback',
-    ...(channelParameterType ? ['parameters'] : []),
-    'js: this.js',
-    'options',
-    'codec: this.codec'
-  ];
   return `
   /**
   * ${description}
   * 
-  ${functionParameters.map((param) => param.jsDoc).join('\n')}
+  ${functionParameters.map((param) => param.jsDoc).join('\n  ')}
   */
-  public ${channelName}(${functionParameters.map((param) => param.parameter).join(', ')}): Promise<Nats.JetStreamSubscription> {
+  public ${channelName}({
+    ${functionParameters.map((param) => param.parameter).join(', \n  ')}
+  }: {
+    ${functionParameters.map((param) => param.parameterType).join(', \n  ')}
+  }): Promise<Nats.JetStreamSubscription> {
     return new Promise(async (resolve, reject) => {
       if (!this.isClosed() && this.nc !== undefined && this.codec !== undefined && this.js !== undefined) {
         try {
-          const sub = await nats.${channelName}({${functionCallParameters.join(', ')}});
+          const sub = await nats.${channelName}({
+            js: this.js,
+            codec: this.codec,
+            ${functionParameters.map((param) => param.parameter).join(', \n            ')}
+          });
           resolve(sub);
         } catch (e: any) {
           reject(e);

--- a/src/codegen/generators/typescript/client/protocols/nats/jetstreamPushSubscription.ts
+++ b/src/codegen/generators/typescript/client/protocols/nats/jetstreamPushSubscription.ts
@@ -48,9 +48,9 @@ export function renderJetStreamPushSubscription({
         ]
       : []),
     {
-      parameter: 'options',
+      parameter: 'options = {}',
       parameterType:
-        'options?: Nats.ConsumerOptsBuilder | Partial<Nats.ConsumerOpts>',
+        'options: Nats.ConsumerOptsBuilder | Partial<Nats.ConsumerOpts>',
       jsDoc: ' * @param options when setting up the subscription'
     }
   ];
@@ -69,9 +69,9 @@ export function renderJetStreamPushSubscription({
   ${functionParameters.map((param) => param.jsDoc).join('\n  ')}
   */
   public ${channelName}({
-    ${functionParameters.map((param) => param.parameter).join(', \n  ')}
+    ${functionParameters.map((param) => param.parameter).join(', \n    ')}
   }: {
-    ${functionParameters.map((param) => param.parameterType).join(', \n  ')}
+    ${functionParameters.map((param) => param.parameterType).join(', \n    ')}
   }): Promise<Nats.JetStreamSubscription> {
     return new Promise(async (resolve, reject) => {
       if (!this.isClosed() && this.nc !== undefined && this.codec !== undefined && this.js !== undefined) {

--- a/src/codegen/generators/typescript/client/protocols/nats/jetstreamPushSubscription.ts
+++ b/src/codegen/generators/typescript/client/protocols/nats/jetstreamPushSubscription.ts
@@ -54,6 +54,13 @@ export function renderJetStreamPushSubscription({
       jsDoc: ' * @param options when setting up the subscription'
     }
   ];
+  const functionCallParameters = [
+    'onDataCallback',
+    ...(channelParameterType ? ['parameters'] : []),
+    'js: this.js',
+    'codec: this.codec',
+    'options'
+  ];
 
   return `
   /**
@@ -70,9 +77,7 @@ export function renderJetStreamPushSubscription({
       if (!this.isClosed() && this.nc !== undefined && this.codec !== undefined && this.js !== undefined) {
         try {
           const sub = await nats.${channelName}({
-            js: this.js,
-            codec: this.codec,
-            ${functionParameters.map((param) => param.parameter).join(', \n            ')}
+            ${functionCallParameters.join(', \n            ')}
           });
           resolve(sub);
         } catch (e: any) {

--- a/src/codegen/generators/typescript/client/protocols/nats/jetstreamPushSubscription.ts
+++ b/src/codegen/generators/typescript/client/protocols/nats/jetstreamPushSubscription.ts
@@ -50,7 +50,7 @@ export function renderJetStreamPushSubscription({
     {
       parameter: 'options',
       parameterType:
-        'options: Nats.ConsumerOptsBuilder | Partial<Nats.ConsumerOpts>',
+        'options?: Nats.ConsumerOptsBuilder | Partial<Nats.ConsumerOpts>',
       jsDoc: ' * @param options when setting up the subscription'
     }
   ];

--- a/src/codegen/generators/typescript/client/protocols/nats/jetstreamPushSubscription.ts
+++ b/src/codegen/generators/typescript/client/protocols/nats/jetstreamPushSubscription.ts
@@ -55,9 +55,9 @@ export function renderJetStreamPushSubscription({
   const functionCallParameters = [
     'onDataCallback',
     ...(channelParameterType ? ['parameters'] : []),
-    'this.js',
+    'js: this.js',
     'options',
-    'this.codec'
+    'codec: this.codec'
   ];
   return `
   /**
@@ -69,7 +69,7 @@ export function renderJetStreamPushSubscription({
     return new Promise(async (resolve, reject) => {
       if (!this.isClosed() && this.nc !== undefined && this.codec !== undefined && this.js !== undefined) {
         try {
-          const sub = await nats.${channelName}(${functionCallParameters.join(', ')});
+          const sub = await nats.${channelName}({${functionCallParameters.join(', ')}});
           resolve(sub);
         } catch (e: any) {
           reject(e);

--- a/test/codegen/generators/typescript/__snapshots__/channels.spec.ts.snap
+++ b/test/codegen/generators/typescript/__snapshots__/channels.spec.ts.snap
@@ -335,25 +335,29 @@ produceToUserSignedup: (
   * @param {consumeFromUserSignedupCallback} onDataCallback to call when messages are received
  * @param kafka the KafkaJS client to subscribe through
  * @param options when setting up the subscription
+ * @param skipMessageValidation turn off runtime validation of outgoing messages
  */
 consumeFromUserSignedup: (
-  onDataCallback: (err?: Error, msg?: MessageTypeModule.MessageType, kafkaMsg?: Kafka.EachMessagePayload) => void, kafka: Kafka.Kafka, options: {fromBeginning: boolean, groupId: string} = {fromBeginning: true, groupId: ''}
+  onDataCallback: (err?: Error, msg?: MessageTypeModule.MessageType, kafkaMsg?: Kafka.EachMessagePayload) => void, kafka: Kafka.Kafka, options: {fromBeginning: boolean, groupId: string} = {fromBeginning: true, groupId: ''}, skipMessageValidation: boolean = false
 ): Promise<Kafka.Consumer> => {
   return new Promise(async (resolve, reject) => {
     try {
       if(!options.groupId) {
-        reject('No group ID provided');
+        return reject('No group ID provided');
       }
       const consumer = kafka.consumer({ groupId: options.groupId });
 
+      
       await consumer.connect();
       await consumer.subscribe({ topic: 'user.signedup', fromBeginning: options.fromBeginning });
       await consumer.run({
         eachMessage: async (kafkaMessage: Kafka.EachMessagePayload) => {
           const { topic, message } = kafkaMessage;
+          const receivedData = message.value?.toString()!;
           
-          const callbackData = MessageTypeModule.unmarshal(message.value?.toString()!);
-  onDataCallback(undefined, callbackData, kafkaMessage);
+          
+const callbackData = MessageTypeModule.unmarshal(receivedData);
+onDataCallback(undefined, callbackData, kafkaMessage);
         }
       });
       resolve(consumer);
@@ -775,25 +779,29 @@ produceToUserSignedup: (
   * @param {consumeFromUserSignedupCallback} onDataCallback to call when messages are received
  * @param kafka the KafkaJS client to subscribe through
  * @param options when setting up the subscription
+ * @param skipMessageValidation turn off runtime validation of outgoing messages
  */
 consumeFromUserSignedup: (
-  onDataCallback: (err?: Error, msg?: MessageTypeModule.MessageType, kafkaMsg?: Kafka.EachMessagePayload) => void, kafka: Kafka.Kafka, options: {fromBeginning: boolean, groupId: string} = {fromBeginning: true, groupId: ''}
+  onDataCallback: (err?: Error, msg?: MessageTypeModule.MessageType, kafkaMsg?: Kafka.EachMessagePayload) => void, kafka: Kafka.Kafka, options: {fromBeginning: boolean, groupId: string} = {fromBeginning: true, groupId: ''}, skipMessageValidation: boolean = false
 ): Promise<Kafka.Consumer> => {
   return new Promise(async (resolve, reject) => {
     try {
       if(!options.groupId) {
-        reject('No group ID provided');
+        return reject('No group ID provided');
       }
       const consumer = kafka.consumer({ groupId: options.groupId });
 
+      
       await consumer.connect();
       await consumer.subscribe({ topic: 'user.signedup', fromBeginning: options.fromBeginning });
       await consumer.run({
         eachMessage: async (kafkaMessage: Kafka.EachMessagePayload) => {
           const { topic, message } = kafkaMessage;
+          const receivedData = message.value?.toString()!;
           
-          const callbackData = MessageTypeModule.unmarshal(message.value?.toString()!);
-  onDataCallback(undefined, callbackData, kafkaMessage);
+          
+const callbackData = MessageTypeModule.unmarshal(receivedData);
+onDataCallback(undefined, callbackData, kafkaMessage);
         }
       });
       resolve(consumer);
@@ -1248,25 +1256,29 @@ produceToPing: (
   * @param {consumeFromPingCallback} onDataCallback to call when messages are received
  * @param kafka the KafkaJS client to subscribe through
  * @param options when setting up the subscription
+ * @param skipMessageValidation turn off runtime validation of outgoing messages
  */
 consumeFromPing: (
-  onDataCallback: (err?: Error, msg?: MessageTypeModule.MessageType, kafkaMsg?: Kafka.EachMessagePayload) => void, kafka: Kafka.Kafka, options: {fromBeginning: boolean, groupId: string} = {fromBeginning: true, groupId: ''}
+  onDataCallback: (err?: Error, msg?: MessageTypeModule.MessageType, kafkaMsg?: Kafka.EachMessagePayload) => void, kafka: Kafka.Kafka, options: {fromBeginning: boolean, groupId: string} = {fromBeginning: true, groupId: ''}, skipMessageValidation: boolean = false
 ): Promise<Kafka.Consumer> => {
   return new Promise(async (resolve, reject) => {
     try {
       if(!options.groupId) {
-        reject('No group ID provided');
+        return reject('No group ID provided');
       }
       const consumer = kafka.consumer({ groupId: options.groupId });
 
+      
       await consumer.connect();
       await consumer.subscribe({ topic: 'ping', fromBeginning: options.fromBeginning });
       await consumer.run({
         eachMessage: async (kafkaMessage: Kafka.EachMessagePayload) => {
           const { topic, message } = kafkaMessage;
+          const receivedData = message.value?.toString()!;
           
-          const callbackData = MessageTypeModule.unmarshal(message.value?.toString()!);
-  onDataCallback(undefined, callbackData, kafkaMessage);
+          
+const callbackData = MessageTypeModule.unmarshal(receivedData);
+onDataCallback(undefined, callbackData, kafkaMessage);
         }
       });
       resolve(consumer);

--- a/test/codegen/generators/typescript/__snapshots__/channels.spec.ts.snap
+++ b/test/codegen/generators/typescript/__snapshots__/channels.spec.ts.snap
@@ -19,9 +19,17 @@ nats: {
  * @param codec the serialization codec to use while transmitting the message
  * @param options to use while publishing the message
  */
-publishToUserSignedup: (
-  message: MessageTypeModule.MessageType, nc: Nats.NatsConnection, codec: any = Nats.JSONCodec(), options?: Nats.PublishOptions
-): Promise<void> => {
+publishToUserSignedup: ({
+  message, 
+  nc, 
+  codec = Nats.JSONCodec(), 
+  options
+}: {
+  message: MessageTypeModule.MessageType, 
+  nc: Nats.NatsConnection, 
+  codec?: Nats.Codec<any>, 
+  options?: Nats.PublishOptions
+}): Promise<void> => {
   return new Promise<void>(async (resolve, reject) => {
     try {
       let dataToSend: any = MessageTypeModule.marshal(message);
@@ -46,18 +54,24 @@ nc.publish('user.signedup', dataToSend, options);
  * Core subscription for \`user.signedup\`
  * 
  * @param {subscribeToUserSignedupCallback} onDataCallback to call when messages are received
- * @param nc the NATS client to subscribe through
+ * @param nc the nats client to setup the subscribe for
  * @param codec the serialization codec to use while receiving the message
  * @param options when setting up the subscription
  * @param skipMessageValidation turn off runtime validation of incoming messages
  */
-subscribeToUserSignedup: (
+subscribeToUserSignedup: ({
+  onDataCallback, 
+  nc, 
+  codec = Nats.JSONCodec(), 
+  options, 
+  skipMessageValidation = false
+}: {
   onDataCallback: (err?: Error, msg?: MessageTypeModule.MessageType, natsMsg?: Nats.Msg) => void, 
   nc: Nats.NatsConnection, 
-  codec: any = Nats.JSONCodec(), 
+  codec?: Nats.Codec<any>, 
   options?: Nats.SubscriptionOptions, 
-  skipMessageValidation: boolean = false
-): Promise<Nats.Subscription> => {
+  skipMessageValidation?: boolean
+}): Promise<Nats.Subscription> => {
   return new Promise(async (resolve, reject) => {
     try {
       const subscription = nc.subscribe('user.signedup', options);
@@ -91,16 +105,22 @@ onDataCallback(undefined, MessageTypeModule.unmarshal(receivedData), msg);
   * @param {jetStreamPullSubscribeToUserSignedupCallback} onDataCallback to call when messages are received
  * @param js the JetStream client to pull subscribe through
  * @param options when setting up the subscription
- * @param codec the serialization codec to use while receiving the message
+ * @param codec the serialization codec to use while transmitting the message
  * @param skipMessageValidation turn off runtime validation of incoming messages
  */
-jetStreamPullSubscribeToUserSignedup: (
+jetStreamPullSubscribeToUserSignedup: ({
+  onDataCallback, 
+  js, 
+  options, 
+  codec = Nats.JSONCodec(), 
+  skipMessageValidation = false
+}: {
   onDataCallback: (err?: Error, msg?: MessageTypeModule.MessageType, jetstreamMsg?: Nats.JsMsg) => void, 
   js: Nats.JetStreamClient, 
   options: Nats.ConsumerOptsBuilder | Partial<Nats.ConsumerOpts>, 
-  codec: any = Nats.JSONCodec(), 
-  skipMessageValidation: boolean = false
-): Promise<Nats.JetStreamPullSubscription> => {
+  codec?: Nats.Codec<any>, 
+  skipMessageValidation?: boolean
+}): Promise<Nats.JetStreamPullSubscription> => {
   return new Promise(async (resolve, reject) => {
     try {
       const subscription = await js.pullSubscribe('user.signedup', options);
@@ -134,16 +154,22 @@ onDataCallback(undefined, MessageTypeModule.unmarshal(receivedData), msg);
   * @param {jetStreamPushSubscriptionFromUserSignedupCallback} onDataCallback to call when messages are received
  * @param js the JetStream client to pull subscribe through
  * @param options when setting up the subscription
- * @param codec the serialization codec to use while receiving the message
+ * @param codec the serialization codec to use while transmitting the message
  * @param skipMessageValidation turn off runtime validation of incoming messages
  */
-jetStreamPushSubscriptionFromUserSignedup: (
+jetStreamPushSubscriptionFromUserSignedup: ({
+  onDataCallback, 
+  js, 
+  options, 
+  codec = Nats.JSONCodec(), 
+  skipMessageValidation = false
+}: {
   onDataCallback: (err?: Error, msg?: MessageTypeModule.MessageType, jetstreamMsg?: Nats.JsMsg) => void, 
   js: Nats.JetStreamClient, 
   options: Nats.ConsumerOptsBuilder | Partial<Nats.ConsumerOpts>, 
-  codec: any = Nats.JSONCodec(), 
-  skipMessageValidation: boolean = false
-): Promise<Nats.JetStreamSubscription> => {
+  codec?: Nats.Codec<any>, 
+  skipMessageValidation?: boolean
+}): Promise<Nats.JetStreamSubscription> => {
   return new Promise(async (resolve, reject) => {
     try {
       const subscription = await js.subscribe('user.signedup', options);
@@ -170,12 +196,17 @@ onDataCallback(undefined, MessageTypeModule.unmarshal(receivedData), msg);
  * @param codec the serialization codec to use while transmitting the message
  * @param options to use while publishing the message
  */
-jetStreamPublishToUserSignedup: (
+jetStreamPublishToUserSignedup: ({
+  message, 
+  js, 
+  codec = Nats.JSONCodec(), 
+  options = {}
+}: {
   message: MessageTypeModule.MessageType, 
   js: Nats.JetStreamClient, 
-  codec: any = Nats.JSONCodec(), 
-  options: Partial<Nats.JetStreamPublishOptions> = {}
-): Promise<void> => {
+  codec?: Nats.Codec<any>, 
+  options?: Partial<Nats.JetStreamPublishOptions>
+}): Promise<void> => {
   return new Promise<void>(async (resolve, reject) => {
     try {
       let dataToSend: any = MessageTypeModule.marshal(message);
@@ -194,12 +225,18 @@ amqp: {
  * 
   * @param message to publish
  * @param amqp the AMQP connection to send over
-
+ * @param options for the AMQP publish exchange operation
  */
-publishToUserSignedupExchange: (
-  message: MessageTypeModule.MessageType, amqp: Amqp.Connection, options?: {exchange: string | undefined} & Amqp.Options.Publish
-): Promise<void> => {
-  return new Promise<void>(async (resolve, reject) => {    
+publishToUserSignedupExchange: ({
+  message, 
+  amqp, 
+  options
+}: {
+  message: MessageTypeModule.MessageType, 
+  amqp: Amqp.Connection, 
+  options?: {exchange: string | undefined} & Amqp.Options.Publish
+}): Promise<void> => {
+  return new Promise<void>(async (resolve, reject) => {
     const exchange = options?.exchange ?? 'undefined';
     if(!exchange) {
       return reject('No exchange value found, please provide one')
@@ -220,11 +257,17 @@ channel.publish(exchange, routingKey, Buffer.from(dataToSend), options);
  * 
   * @param message to publish
  * @param amqp the AMQP connection to send over
-
+ * @param options for the AMQP publish queue operation
  */
-publishToUserSignedupQueue: (
-  message: MessageTypeModule.MessageType, amqp: Amqp.Connection, options?: Amqp.Options.Publish
-): Promise<void> => {
+publishToUserSignedupQueue: ({
+  message, 
+  amqp, 
+  options
+}: {
+  message: MessageTypeModule.MessageType, 
+  amqp: Amqp.Connection, 
+  options?: Amqp.Options.Publish
+}): Promise<void> => {
   return new Promise<void>(async (resolve, reject) => {
     try {
       let dataToSend: any = MessageTypeModule.marshal(message);
@@ -242,15 +285,20 @@ channel.sendToQueue(queue, Buffer.from(dataToSend), options);
  * 
   * @param {subscribeToUserSignedupQueueCallback} onDataCallback to call when messages are received
  * @param amqp the AMQP connection to receive from
-
+ * @param options for the AMQP subscribe queue operation
  * @param skipMessageValidation turn off runtime validation of incoming messages
  */
-subscribeToUserSignedupQueue: (
-  onDataCallback: (err?: Error, msg?: MessageTypeModule.MessageType, amqpMsg?: Amqp.ConsumeMessage) => void,
-  amqp: Amqp.Connection,
-  options?: Amqp.Options.Consume,
-  skipMessageValidation: boolean = false
-): Promise<Amqp.Channel> => {
+subscribeToUserSignedupQueue: ({
+  onDataCallback, 
+  amqp, 
+  options, 
+  skipMessageValidation = false
+}: {
+  onDataCallback: (err?: Error, msg?: MessageTypeModule.MessageType, amqpMsg?: Amqp.ConsumeMessage) => void, 
+  amqp: Amqp.Connection, 
+  options?: Amqp.Options.Consume, 
+  skipMessageValidation?: boolean
+}): Promise<Amqp.Channel> => {
   return new Promise(async (resolve, reject) => {
     try {
       const channel = await amqp.createChannel();
@@ -279,9 +327,13 @@ mqtt: {
   * @param message to publish
  * @param mqtt the MQTT client to publish from
  */
-publishToUserSignedup: (
-  message: MessageTypeModule.MessageType, mqtt: Mqtt.MqttClient
-): Promise<void> => {
+publishToUserSignedup: ({
+  message, 
+  mqtt
+}: {
+  message: MessageTypeModule.MessageType, 
+  mqtt: Mqtt.MqttClient
+}): Promise<void> => {
   return new Promise<void>(async (resolve, reject) => {
     try {
       let dataToSend: any = MessageTypeModule.marshal(message);
@@ -300,9 +352,13 @@ kafka: {
   * @param message to publish
  * @param kafka the KafkaJS client to publish from
  */
-produceToUserSignedup: (
-  message: MessageTypeModule.MessageType, kafka: Kafka.Kafka
-): Promise<Kafka.Producer> => {
+produceToUserSignedup: ({
+  message, 
+  kafka
+}: {
+  message: MessageTypeModule.MessageType, 
+  kafka: Kafka.Kafka
+}): Promise<Kafka.Producer> => {
   return new Promise(async (resolve, reject) => {
     try {
       let dataToSend: any = MessageTypeModule.marshal(message);
@@ -335,11 +391,19 @@ produceToUserSignedup: (
   * @param {consumeFromUserSignedupCallback} onDataCallback to call when messages are received
  * @param kafka the KafkaJS client to subscribe through
  * @param options when setting up the subscription
- * @param skipMessageValidation turn off runtime validation of outgoing messages
+ * @param skipMessageValidation turn off runtime validation of incoming messages
  */
-consumeFromUserSignedup: (
-  onDataCallback: (err?: Error, msg?: MessageTypeModule.MessageType, kafkaMsg?: Kafka.EachMessagePayload) => void, kafka: Kafka.Kafka, options: {fromBeginning: boolean, groupId: string} = {fromBeginning: true, groupId: ''}, skipMessageValidation: boolean = false
-): Promise<Kafka.Consumer> => {
+consumeFromUserSignedup: ({
+  onDataCallback, 
+  kafka, 
+  options = {fromBeginning: true, groupId: ''}, 
+  skipMessageValidation = false
+}: {
+  onDataCallback: (err?: Error, msg?: MessageTypeModule.MessageType, kafkaMsg?: Kafka.EachMessagePayload) => void, 
+  kafka: Kafka.Kafka, 
+  options: {fromBeginning: boolean, groupId: string}, 
+  skipMessageValidation?: boolean
+}): Promise<Kafka.Consumer> => {
   return new Promise(async (resolve, reject) => {
     try {
       if(!options.groupId) {
@@ -375,11 +439,15 @@ event_source: {
  * @param options additionally used to handle the event source
  * @param skipMessageValidation turn off runtime validation of incoming messages
  */
-listenForUserSignedup: async (
+listenForUserSignedup: async ({
+  callback, 
+  options, 
+  skipMessageValidation = false
+}: {
   callback: (error?: Error, messageEvent?: MessageTypeModule.MessageType) => void, 
   options: {authorization?: string, onClose?: (err?: string) => void, baseUrl: string, headers?: Record<string, string>}, 
-  skipMessageValidation: boolean = false
-) => {
+  skipMessageValidation?: boolean
+}) => {
 	let eventsUrl: string = 'user/signedup';
 	const url = \`\${options.baseUrl}/\${eventsUrl}\`
   const headers: Record<string, string> = {
@@ -418,10 +486,13 @@ listenForUserSignedup: async (
 	})
 }
 ,
-registerUserSignedup: (
+registerUserSignedup: ({
+  router, 
+  callback
+}: {
   router: Router, 
   callback: ((req: Request, res: Response, next: NextFunction, sendEvent: (message: MessageTypeModule.MessageType) => void) => void) | ((req: Request, res: Response, next: NextFunction, sendEvent: (message: MessageTypeModule.MessageType) => void) => Promise<void>)
-) => {
+}) => {
   const event = '/user/signedup';
   router.get(event, async (req, res, next) => {
     
@@ -463,9 +534,17 @@ nats: {
  * @param codec the serialization codec to use while transmitting the message
  * @param options to use while publishing the message
  */
-publishToUserSignedup: (
-  message: MessageTypeModule.MessageType, nc: Nats.NatsConnection, codec: any = Nats.JSONCodec(), options?: Nats.PublishOptions
-): Promise<void> => {
+publishToUserSignedup: ({
+  message, 
+  nc, 
+  codec = Nats.JSONCodec(), 
+  options
+}: {
+  message: MessageTypeModule.MessageType, 
+  nc: Nats.NatsConnection, 
+  codec?: Nats.Codec<any>, 
+  options?: Nats.PublishOptions
+}): Promise<void> => {
   return new Promise<void>(async (resolve, reject) => {
     try {
       let dataToSend: any = MessageTypeModule.marshal(message);
@@ -490,18 +569,24 @@ nc.publish('user.signedup', dataToSend, options);
  * Core subscription for \`user.signedup\`
  * 
  * @param {subscribeToUserSignedupCallback} onDataCallback to call when messages are received
- * @param nc the NATS client to subscribe through
+ * @param nc the nats client to setup the subscribe for
  * @param codec the serialization codec to use while receiving the message
  * @param options when setting up the subscription
  * @param skipMessageValidation turn off runtime validation of incoming messages
  */
-subscribeToUserSignedup: (
+subscribeToUserSignedup: ({
+  onDataCallback, 
+  nc, 
+  codec = Nats.JSONCodec(), 
+  options, 
+  skipMessageValidation = false
+}: {
   onDataCallback: (err?: Error, msg?: MessageTypeModule.MessageType, natsMsg?: Nats.Msg) => void, 
   nc: Nats.NatsConnection, 
-  codec: any = Nats.JSONCodec(), 
+  codec?: Nats.Codec<any>, 
   options?: Nats.SubscriptionOptions, 
-  skipMessageValidation: boolean = false
-): Promise<Nats.Subscription> => {
+  skipMessageValidation?: boolean
+}): Promise<Nats.Subscription> => {
   return new Promise(async (resolve, reject) => {
     try {
       const subscription = nc.subscribe('user.signedup', options);
@@ -535,16 +620,22 @@ onDataCallback(undefined, MessageTypeModule.unmarshal(receivedData), msg);
   * @param {jetStreamPullSubscribeToUserSignedupCallback} onDataCallback to call when messages are received
  * @param js the JetStream client to pull subscribe through
  * @param options when setting up the subscription
- * @param codec the serialization codec to use while receiving the message
+ * @param codec the serialization codec to use while transmitting the message
  * @param skipMessageValidation turn off runtime validation of incoming messages
  */
-jetStreamPullSubscribeToUserSignedup: (
+jetStreamPullSubscribeToUserSignedup: ({
+  onDataCallback, 
+  js, 
+  options, 
+  codec = Nats.JSONCodec(), 
+  skipMessageValidation = false
+}: {
   onDataCallback: (err?: Error, msg?: MessageTypeModule.MessageType, jetstreamMsg?: Nats.JsMsg) => void, 
   js: Nats.JetStreamClient, 
   options: Nats.ConsumerOptsBuilder | Partial<Nats.ConsumerOpts>, 
-  codec: any = Nats.JSONCodec(), 
-  skipMessageValidation: boolean = false
-): Promise<Nats.JetStreamPullSubscription> => {
+  codec?: Nats.Codec<any>, 
+  skipMessageValidation?: boolean
+}): Promise<Nats.JetStreamPullSubscription> => {
   return new Promise(async (resolve, reject) => {
     try {
       const subscription = await js.pullSubscribe('user.signedup', options);
@@ -578,16 +669,22 @@ onDataCallback(undefined, MessageTypeModule.unmarshal(receivedData), msg);
   * @param {jetStreamPushSubscriptionFromUserSignedupCallback} onDataCallback to call when messages are received
  * @param js the JetStream client to pull subscribe through
  * @param options when setting up the subscription
- * @param codec the serialization codec to use while receiving the message
+ * @param codec the serialization codec to use while transmitting the message
  * @param skipMessageValidation turn off runtime validation of incoming messages
  */
-jetStreamPushSubscriptionFromUserSignedup: (
+jetStreamPushSubscriptionFromUserSignedup: ({
+  onDataCallback, 
+  js, 
+  options, 
+  codec = Nats.JSONCodec(), 
+  skipMessageValidation = false
+}: {
   onDataCallback: (err?: Error, msg?: MessageTypeModule.MessageType, jetstreamMsg?: Nats.JsMsg) => void, 
   js: Nats.JetStreamClient, 
   options: Nats.ConsumerOptsBuilder | Partial<Nats.ConsumerOpts>, 
-  codec: any = Nats.JSONCodec(), 
-  skipMessageValidation: boolean = false
-): Promise<Nats.JetStreamSubscription> => {
+  codec?: Nats.Codec<any>, 
+  skipMessageValidation?: boolean
+}): Promise<Nats.JetStreamSubscription> => {
   return new Promise(async (resolve, reject) => {
     try {
       const subscription = await js.subscribe('user.signedup', options);
@@ -614,12 +711,17 @@ onDataCallback(undefined, MessageTypeModule.unmarshal(receivedData), msg);
  * @param codec the serialization codec to use while transmitting the message
  * @param options to use while publishing the message
  */
-jetStreamPublishToUserSignedup: (
+jetStreamPublishToUserSignedup: ({
+  message, 
+  js, 
+  codec = Nats.JSONCodec(), 
+  options = {}
+}: {
   message: MessageTypeModule.MessageType, 
   js: Nats.JetStreamClient, 
-  codec: any = Nats.JSONCodec(), 
-  options: Partial<Nats.JetStreamPublishOptions> = {}
-): Promise<void> => {
+  codec?: Nats.Codec<any>, 
+  options?: Partial<Nats.JetStreamPublishOptions>
+}): Promise<void> => {
   return new Promise<void>(async (resolve, reject) => {
     try {
       let dataToSend: any = MessageTypeModule.marshal(message);
@@ -638,12 +740,18 @@ amqp: {
  * 
   * @param message to publish
  * @param amqp the AMQP connection to send over
-
+ * @param options for the AMQP publish exchange operation
  */
-publishToUserSignedupExchange: (
-  message: MessageTypeModule.MessageType, amqp: Amqp.Connection, options?: {exchange: string | undefined} & Amqp.Options.Publish
-): Promise<void> => {
-  return new Promise<void>(async (resolve, reject) => {    
+publishToUserSignedupExchange: ({
+  message, 
+  amqp, 
+  options
+}: {
+  message: MessageTypeModule.MessageType, 
+  amqp: Amqp.Connection, 
+  options?: {exchange: string | undefined} & Amqp.Options.Publish
+}): Promise<void> => {
+  return new Promise<void>(async (resolve, reject) => {
     const exchange = options?.exchange ?? 'undefined';
     if(!exchange) {
       return reject('No exchange value found, please provide one')
@@ -664,11 +772,17 @@ channel.publish(exchange, routingKey, Buffer.from(dataToSend), options);
  * 
   * @param message to publish
  * @param amqp the AMQP connection to send over
-
+ * @param options for the AMQP publish queue operation
  */
-publishToUserSignedupQueue: (
-  message: MessageTypeModule.MessageType, amqp: Amqp.Connection, options?: Amqp.Options.Publish
-): Promise<void> => {
+publishToUserSignedupQueue: ({
+  message, 
+  amqp, 
+  options
+}: {
+  message: MessageTypeModule.MessageType, 
+  amqp: Amqp.Connection, 
+  options?: Amqp.Options.Publish
+}): Promise<void> => {
   return new Promise<void>(async (resolve, reject) => {
     try {
       let dataToSend: any = MessageTypeModule.marshal(message);
@@ -686,15 +800,20 @@ channel.sendToQueue(queue, Buffer.from(dataToSend), options);
  * 
   * @param {subscribeToUserSignedupQueueCallback} onDataCallback to call when messages are received
  * @param amqp the AMQP connection to receive from
-
+ * @param options for the AMQP subscribe queue operation
  * @param skipMessageValidation turn off runtime validation of incoming messages
  */
-subscribeToUserSignedupQueue: (
-  onDataCallback: (err?: Error, msg?: MessageTypeModule.MessageType, amqpMsg?: Amqp.ConsumeMessage) => void,
-  amqp: Amqp.Connection,
-  options?: Amqp.Options.Consume,
-  skipMessageValidation: boolean = false
-): Promise<Amqp.Channel> => {
+subscribeToUserSignedupQueue: ({
+  onDataCallback, 
+  amqp, 
+  options, 
+  skipMessageValidation = false
+}: {
+  onDataCallback: (err?: Error, msg?: MessageTypeModule.MessageType, amqpMsg?: Amqp.ConsumeMessage) => void, 
+  amqp: Amqp.Connection, 
+  options?: Amqp.Options.Consume, 
+  skipMessageValidation?: boolean
+}): Promise<Amqp.Channel> => {
   return new Promise(async (resolve, reject) => {
     try {
       const channel = await amqp.createChannel();
@@ -723,9 +842,13 @@ mqtt: {
   * @param message to publish
  * @param mqtt the MQTT client to publish from
  */
-publishToUserSignedup: (
-  message: MessageTypeModule.MessageType, mqtt: Mqtt.MqttClient
-): Promise<void> => {
+publishToUserSignedup: ({
+  message, 
+  mqtt
+}: {
+  message: MessageTypeModule.MessageType, 
+  mqtt: Mqtt.MqttClient
+}): Promise<void> => {
   return new Promise<void>(async (resolve, reject) => {
     try {
       let dataToSend: any = MessageTypeModule.marshal(message);
@@ -744,9 +867,13 @@ kafka: {
   * @param message to publish
  * @param kafka the KafkaJS client to publish from
  */
-produceToUserSignedup: (
-  message: MessageTypeModule.MessageType, kafka: Kafka.Kafka
-): Promise<Kafka.Producer> => {
+produceToUserSignedup: ({
+  message, 
+  kafka
+}: {
+  message: MessageTypeModule.MessageType, 
+  kafka: Kafka.Kafka
+}): Promise<Kafka.Producer> => {
   return new Promise(async (resolve, reject) => {
     try {
       let dataToSend: any = MessageTypeModule.marshal(message);
@@ -779,11 +906,19 @@ produceToUserSignedup: (
   * @param {consumeFromUserSignedupCallback} onDataCallback to call when messages are received
  * @param kafka the KafkaJS client to subscribe through
  * @param options when setting up the subscription
- * @param skipMessageValidation turn off runtime validation of outgoing messages
+ * @param skipMessageValidation turn off runtime validation of incoming messages
  */
-consumeFromUserSignedup: (
-  onDataCallback: (err?: Error, msg?: MessageTypeModule.MessageType, kafkaMsg?: Kafka.EachMessagePayload) => void, kafka: Kafka.Kafka, options: {fromBeginning: boolean, groupId: string} = {fromBeginning: true, groupId: ''}, skipMessageValidation: boolean = false
-): Promise<Kafka.Consumer> => {
+consumeFromUserSignedup: ({
+  onDataCallback, 
+  kafka, 
+  options = {fromBeginning: true, groupId: ''}, 
+  skipMessageValidation = false
+}: {
+  onDataCallback: (err?: Error, msg?: MessageTypeModule.MessageType, kafkaMsg?: Kafka.EachMessagePayload) => void, 
+  kafka: Kafka.Kafka, 
+  options: {fromBeginning: boolean, groupId: string}, 
+  skipMessageValidation?: boolean
+}): Promise<Kafka.Consumer> => {
   return new Promise(async (resolve, reject) => {
     try {
       if(!options.groupId) {
@@ -819,11 +954,15 @@ event_source: {
  * @param options additionally used to handle the event source
  * @param skipMessageValidation turn off runtime validation of incoming messages
  */
-listenForUserSignedup: async (
+listenForUserSignedup: async ({
+  callback, 
+  options, 
+  skipMessageValidation = false
+}: {
   callback: (error?: Error, messageEvent?: MessageTypeModule.MessageType) => void, 
   options: {authorization?: string, onClose?: (err?: string) => void, baseUrl: string, headers?: Record<string, string>}, 
-  skipMessageValidation: boolean = false
-) => {
+  skipMessageValidation?: boolean
+}) => {
 	let eventsUrl: string = 'user/signedup';
 	const url = \`\${options.baseUrl}/\${eventsUrl}\`
   const headers: Record<string, string> = {
@@ -862,10 +1001,13 @@ listenForUserSignedup: async (
 	})
 }
 ,
-registerUserSignedup: (
+registerUserSignedup: ({
+  router, 
+  callback
+}: {
   router: Router, 
   callback: ((req: Request, res: Response, next: NextFunction, sendEvent: (message: MessageTypeModule.MessageType) => void) => void) | ((req: Request, res: Response, next: NextFunction, sendEvent: (message: MessageTypeModule.MessageType) => void) => Promise<void>)
-) => {
+}) => {
   const event = '/user/signedup';
   router.get(event, async (req, res, next) => {
     
@@ -902,12 +1044,17 @@ nats: {
  * @param codec the serialization codec to use while transmitting the message
  * @param options to use while publishing the message
  */
-jetStreamPublishToUserSignedup: (
+jetStreamPublishToUserSignedup: ({
+  message, 
+  js, 
+  codec = Nats.JSONCodec(), 
+  options = {}
+}: {
   message: MessageTypeModule.MessageType, 
   js: Nats.JetStreamClient, 
-  codec: any = Nats.JSONCodec(), 
-  options: Partial<Nats.JetStreamPublishOptions> = {}
-): Promise<void> => {
+  codec?: Nats.Codec<any>, 
+  options?: Partial<Nats.JetStreamPublishOptions>
+}): Promise<void> => {
   return new Promise<void>(async (resolve, reject) => {
     try {
       let dataToSend: any = MessageTypeModule.marshal(message);
@@ -940,9 +1087,17 @@ nats: {
  * @param codec the serialization codec to use while transmitting the message
  * @param options to use while publishing the message
  */
-publishToPing: (
-  message: MessageTypeModule.MessageType, nc: Nats.NatsConnection, codec: any = Nats.JSONCodec(), options?: Nats.PublishOptions
-): Promise<void> => {
+publishToPing: ({
+  message, 
+  nc, 
+  codec = Nats.JSONCodec(), 
+  options
+}: {
+  message: MessageTypeModule.MessageType, 
+  nc: Nats.NatsConnection, 
+  codec?: Nats.Codec<any>, 
+  options?: Nats.PublishOptions
+}): Promise<void> => {
   return new Promise<void>(async (resolve, reject) => {
     try {
       let dataToSend: any = MessageTypeModule.marshal(message);
@@ -967,18 +1122,24 @@ nc.publish('ping', dataToSend, options);
  * Core subscription for \`ping\`
  * 
  * @param {subscribeToPingCallback} onDataCallback to call when messages are received
- * @param nc the NATS client to subscribe through
+ * @param nc the nats client to setup the subscribe for
  * @param codec the serialization codec to use while receiving the message
  * @param options when setting up the subscription
  * @param skipMessageValidation turn off runtime validation of incoming messages
  */
-subscribeToPing: (
+subscribeToPing: ({
+  onDataCallback, 
+  nc, 
+  codec = Nats.JSONCodec(), 
+  options, 
+  skipMessageValidation = false
+}: {
   onDataCallback: (err?: Error, msg?: MessageTypeModule.MessageType, natsMsg?: Nats.Msg) => void, 
   nc: Nats.NatsConnection, 
-  codec: any = Nats.JSONCodec(), 
+  codec?: Nats.Codec<any>, 
   options?: Nats.SubscriptionOptions, 
-  skipMessageValidation: boolean = false
-): Promise<Nats.Subscription> => {
+  skipMessageValidation?: boolean
+}): Promise<Nats.Subscription> => {
   return new Promise(async (resolve, reject) => {
     try {
       const subscription = nc.subscribe('ping', options);
@@ -1012,16 +1173,22 @@ onDataCallback(undefined, MessageTypeModule.unmarshal(receivedData), msg);
   * @param {jetStreamPullSubscribeToPingCallback} onDataCallback to call when messages are received
  * @param js the JetStream client to pull subscribe through
  * @param options when setting up the subscription
- * @param codec the serialization codec to use while receiving the message
+ * @param codec the serialization codec to use while transmitting the message
  * @param skipMessageValidation turn off runtime validation of incoming messages
  */
-jetStreamPullSubscribeToPing: (
+jetStreamPullSubscribeToPing: ({
+  onDataCallback, 
+  js, 
+  options, 
+  codec = Nats.JSONCodec(), 
+  skipMessageValidation = false
+}: {
   onDataCallback: (err?: Error, msg?: MessageTypeModule.MessageType, jetstreamMsg?: Nats.JsMsg) => void, 
   js: Nats.JetStreamClient, 
   options: Nats.ConsumerOptsBuilder | Partial<Nats.ConsumerOpts>, 
-  codec: any = Nats.JSONCodec(), 
-  skipMessageValidation: boolean = false
-): Promise<Nats.JetStreamPullSubscription> => {
+  codec?: Nats.Codec<any>, 
+  skipMessageValidation?: boolean
+}): Promise<Nats.JetStreamPullSubscription> => {
   return new Promise(async (resolve, reject) => {
     try {
       const subscription = await js.pullSubscribe('ping', options);
@@ -1055,16 +1222,22 @@ onDataCallback(undefined, MessageTypeModule.unmarshal(receivedData), msg);
   * @param {jetStreamPushSubscriptionFromPingCallback} onDataCallback to call when messages are received
  * @param js the JetStream client to pull subscribe through
  * @param options when setting up the subscription
- * @param codec the serialization codec to use while receiving the message
+ * @param codec the serialization codec to use while transmitting the message
  * @param skipMessageValidation turn off runtime validation of incoming messages
  */
-jetStreamPushSubscriptionFromPing: (
+jetStreamPushSubscriptionFromPing: ({
+  onDataCallback, 
+  js, 
+  options, 
+  codec = Nats.JSONCodec(), 
+  skipMessageValidation = false
+}: {
   onDataCallback: (err?: Error, msg?: MessageTypeModule.MessageType, jetstreamMsg?: Nats.JsMsg) => void, 
   js: Nats.JetStreamClient, 
   options: Nats.ConsumerOptsBuilder | Partial<Nats.ConsumerOpts>, 
-  codec: any = Nats.JSONCodec(), 
-  skipMessageValidation: boolean = false
-): Promise<Nats.JetStreamSubscription> => {
+  codec?: Nats.Codec<any>, 
+  skipMessageValidation?: boolean
+}): Promise<Nats.JetStreamSubscription> => {
   return new Promise(async (resolve, reject) => {
     try {
       const subscription = await js.subscribe('ping', options);
@@ -1091,12 +1264,17 @@ onDataCallback(undefined, MessageTypeModule.unmarshal(receivedData), msg);
  * @param codec the serialization codec to use while transmitting the message
  * @param options to use while publishing the message
  */
-jetStreamPublishToPing: (
+jetStreamPublishToPing: ({
+  message, 
+  js, 
+  codec = Nats.JSONCodec(), 
+  options = {}
+}: {
   message: MessageTypeModule.MessageType, 
   js: Nats.JetStreamClient, 
-  codec: any = Nats.JSONCodec(), 
-  options: Partial<Nats.JetStreamPublishOptions> = {}
-): Promise<void> => {
+  codec?: Nats.Codec<any>, 
+  options?: Partial<Nats.JetStreamPublishOptions>
+}): Promise<void> => {
   return new Promise<void>(async (resolve, reject) => {
     try {
       let dataToSend: any = MessageTypeModule.marshal(message);
@@ -1115,12 +1293,18 @@ amqp: {
  * 
   * @param message to publish
  * @param amqp the AMQP connection to send over
-
+ * @param options for the AMQP publish exchange operation
  */
-publishToPingExchange: (
-  message: MessageTypeModule.MessageType, amqp: Amqp.Connection, options?: {exchange: string | undefined} & Amqp.Options.Publish
-): Promise<void> => {
-  return new Promise<void>(async (resolve, reject) => {    
+publishToPingExchange: ({
+  message, 
+  amqp, 
+  options
+}: {
+  message: MessageTypeModule.MessageType, 
+  amqp: Amqp.Connection, 
+  options?: {exchange: string | undefined} & Amqp.Options.Publish
+}): Promise<void> => {
+  return new Promise<void>(async (resolve, reject) => {
     const exchange = options?.exchange ?? 'undefined';
     if(!exchange) {
       return reject('No exchange value found, please provide one')
@@ -1141,11 +1325,17 @@ channel.publish(exchange, routingKey, Buffer.from(dataToSend), options);
  * 
   * @param message to publish
  * @param amqp the AMQP connection to send over
-
+ * @param options for the AMQP publish queue operation
  */
-publishToPingQueue: (
-  message: MessageTypeModule.MessageType, amqp: Amqp.Connection, options?: Amqp.Options.Publish
-): Promise<void> => {
+publishToPingQueue: ({
+  message, 
+  amqp, 
+  options
+}: {
+  message: MessageTypeModule.MessageType, 
+  amqp: Amqp.Connection, 
+  options?: Amqp.Options.Publish
+}): Promise<void> => {
   return new Promise<void>(async (resolve, reject) => {
     try {
       let dataToSend: any = MessageTypeModule.marshal(message);
@@ -1163,15 +1353,20 @@ channel.sendToQueue(queue, Buffer.from(dataToSend), options);
  * 
   * @param {subscribeToPingQueueCallback} onDataCallback to call when messages are received
  * @param amqp the AMQP connection to receive from
-
+ * @param options for the AMQP subscribe queue operation
  * @param skipMessageValidation turn off runtime validation of incoming messages
  */
-subscribeToPingQueue: (
-  onDataCallback: (err?: Error, msg?: MessageTypeModule.MessageType, amqpMsg?: Amqp.ConsumeMessage) => void,
-  amqp: Amqp.Connection,
-  options?: Amqp.Options.Consume,
-  skipMessageValidation: boolean = false
-): Promise<Amqp.Channel> => {
+subscribeToPingQueue: ({
+  onDataCallback, 
+  amqp, 
+  options, 
+  skipMessageValidation = false
+}: {
+  onDataCallback: (err?: Error, msg?: MessageTypeModule.MessageType, amqpMsg?: Amqp.ConsumeMessage) => void, 
+  amqp: Amqp.Connection, 
+  options?: Amqp.Options.Consume, 
+  skipMessageValidation?: boolean
+}): Promise<Amqp.Channel> => {
   return new Promise(async (resolve, reject) => {
     try {
       const channel = await amqp.createChannel();
@@ -1200,9 +1395,13 @@ mqtt: {
   * @param message to publish
  * @param mqtt the MQTT client to publish from
  */
-publishToPing: (
-  message: MessageTypeModule.MessageType, mqtt: Mqtt.MqttClient
-): Promise<void> => {
+publishToPing: ({
+  message, 
+  mqtt
+}: {
+  message: MessageTypeModule.MessageType, 
+  mqtt: Mqtt.MqttClient
+}): Promise<void> => {
   return new Promise<void>(async (resolve, reject) => {
     try {
       let dataToSend: any = MessageTypeModule.marshal(message);
@@ -1221,9 +1420,13 @@ kafka: {
   * @param message to publish
  * @param kafka the KafkaJS client to publish from
  */
-produceToPing: (
-  message: MessageTypeModule.MessageType, kafka: Kafka.Kafka
-): Promise<Kafka.Producer> => {
+produceToPing: ({
+  message, 
+  kafka
+}: {
+  message: MessageTypeModule.MessageType, 
+  kafka: Kafka.Kafka
+}): Promise<Kafka.Producer> => {
   return new Promise(async (resolve, reject) => {
     try {
       let dataToSend: any = MessageTypeModule.marshal(message);
@@ -1256,11 +1459,19 @@ produceToPing: (
   * @param {consumeFromPingCallback} onDataCallback to call when messages are received
  * @param kafka the KafkaJS client to subscribe through
  * @param options when setting up the subscription
- * @param skipMessageValidation turn off runtime validation of outgoing messages
+ * @param skipMessageValidation turn off runtime validation of incoming messages
  */
-consumeFromPing: (
-  onDataCallback: (err?: Error, msg?: MessageTypeModule.MessageType, kafkaMsg?: Kafka.EachMessagePayload) => void, kafka: Kafka.Kafka, options: {fromBeginning: boolean, groupId: string} = {fromBeginning: true, groupId: ''}, skipMessageValidation: boolean = false
-): Promise<Kafka.Consumer> => {
+consumeFromPing: ({
+  onDataCallback, 
+  kafka, 
+  options = {fromBeginning: true, groupId: ''}, 
+  skipMessageValidation = false
+}: {
+  onDataCallback: (err?: Error, msg?: MessageTypeModule.MessageType, kafkaMsg?: Kafka.EachMessagePayload) => void, 
+  kafka: Kafka.Kafka, 
+  options: {fromBeginning: boolean, groupId: string}, 
+  skipMessageValidation?: boolean
+}): Promise<Kafka.Consumer> => {
   return new Promise(async (resolve, reject) => {
     try {
       if(!options.groupId) {
@@ -1296,11 +1507,15 @@ event_source: {
  * @param options additionally used to handle the event source
  * @param skipMessageValidation turn off runtime validation of incoming messages
  */
-listenForPing: async (
+listenForPing: async ({
+  callback, 
+  options, 
+  skipMessageValidation = false
+}: {
   callback: (error?: Error, messageEvent?: MessageTypeModule.MessageType) => void, 
   options: {authorization?: string, onClose?: (err?: string) => void, baseUrl: string, headers?: Record<string, string>}, 
-  skipMessageValidation: boolean = false
-) => {
+  skipMessageValidation?: boolean
+}) => {
 	let eventsUrl: string = '/ping';
 	const url = \`\${options.baseUrl}/\${eventsUrl}\`
   const headers: Record<string, string> = {
@@ -1339,10 +1554,13 @@ listenForPing: async (
 	})
 }
 ,
-registerPing: (
+registerPing: ({
+  router, 
+  callback
+}: {
   router: Router, 
   callback: ((req: Request, res: Response, next: NextFunction, sendEvent: (message: MessageTypeModule.MessageType) => void) => void) | ((req: Request, res: Response, next: NextFunction, sendEvent: (message: MessageTypeModule.MessageType) => void) => Promise<void>)
-) => {
+}) => {
   const event = '/ping';
   router.get(event, async (req, res, next) => {
     

--- a/test/runtime/docker-compose-kafka.yml
+++ b/test/runtime/docker-compose-kafka.yml
@@ -18,7 +18,6 @@ services:
       KAFKA_LISTENERS: INSIDE://0.0.0.0:9092,OUTSIDE://0.0.0.0:9093
       KAFKA_INTER_BROKER_LISTENER_NAME: INSIDE
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
-      KAFKA_CREATE_TOPICS: "noparameters:1:1,user.signedup.test.asyncapi:1:1"
     networks:
       - kafka-net
 networks:

--- a/test/runtime/typescript/test/channels/eventsource.spec.ts
+++ b/test/runtime/typescript/test/channels/eventsource.spec.ts
@@ -24,23 +24,23 @@ describe('event source', () => {
           const app = express()
           app.use(express.json({ limit: '3000kb' }))
           app.use(express.urlencoded({ extended: true }))
-          registerNoParameter(router, (req, res, next, sendEvent) => {
+          registerNoParameter({router, callback: (req, res, next, sendEvent) => {
             sendEvent(testMessage);
             res.end();
-          })
+          }})
           app.use(router)
           const portToUse = testPort()
           server = app.listen(portToUse, async () => {
-            await listenForNoParameter((err, msg) => {
+            await listenForNoParameter({callback: (err, msg) => {
               try {
                 expect(msg?.marshal()).toEqual(testMessage.marshal());
                 resolve();
               } catch (e) {
                 reject(e);
               }
-            }, {
+            }, options: {
               baseUrl: 'http://localhost:' + portToUse,
-            })
+            }})
           })
         });
       });
@@ -56,14 +56,14 @@ describe('event source', () => {
           const app = express()
           app.use(express.json({ limit: '3000kb' }))
           app.use(express.urlencoded({ extended: true }))
-          registerSendUserSignedup(router, (req, res, next, parameters, sendEvent) => {
+          registerSendUserSignedup({router, callback: (req, res, next, parameters, sendEvent) => {
             sendEvent(testMessage);
             res.end();
-          })
+          }})
           app.use(router)
           const portToUse = testPort()
           server = app.listen(portToUse, async () => {
-            await listenForReceiveUserSignedup((err, msg) => {
+            await listenForReceiveUserSignedup({callback: (err, msg) => {
               try {
                 expect(msg?.marshal()).toEqual(testMessage.marshal());
                 resolve();
@@ -71,10 +71,10 @@ describe('event source', () => {
                 reject(e);
               }
             },
-              testParameters,
-              {
+              parameters: testParameters,
+              options: {
                 baseUrl: 'http://localhost:' + portToUse,
-              })
+              }})
           })
         });
       });
@@ -84,15 +84,15 @@ describe('event source', () => {
           const app = express()
           app.use(express.json({ limit: '3000kb' }))
           app.use(express.urlencoded({ extended: true }))
-          registerSendUserSignedup(router, (req, res, next, parameters, sendEvent) => {
+          registerSendUserSignedup({router, callback: (req, res, next, parameters, sendEvent) => {
             sendEvent(invalidMessage);
             res.end();
-          })
+          }})
           app.use(router)
           const portToUse = testPort()
           server = app.listen(portToUse, async () => {
-            await listenForReceiveUserSignedup(
-              (err) => {
+            await listenForReceiveUserSignedup({
+              callback: (err) => {
                 try {
                   expect(err).toBeDefined();
                   expect(err?.message).toEqual('Invalid message payload received');
@@ -102,10 +102,10 @@ describe('event source', () => {
                   reject(e);
                 }
               },
-              testParameters,
-              {
+              parameters: testParameters,
+              options: {
                 baseUrl: 'http://localhost:' + portToUse,
-              }
+              }}
             )
           })
         });

--- a/test/runtime/typescript/test/channels/kafka.spec.ts
+++ b/test/runtime/typescript/test/channels/kafka.spec.ts
@@ -54,7 +54,7 @@ describe('kafka', () => {
         // eslint-disable-next-line no-async-promise-executor
         let consumer;
         return new Promise<void>(async (resolve, reject) => {
-          consumer = await consumeFromReceiveUserSignedup(async (err, msg, parameters) => {
+          consumer = await consumeFromReceiveUserSignedup({onDataCallback: async (err, msg, parameters) => {
             try {
               expect(msg).toBeUndefined();
               expect(err).toBeDefined();
@@ -65,8 +65,8 @@ describe('kafka', () => {
             } catch (error) {
               reject(error);
             }
-          }, new UserSignedupParameters({myParameter: 'test', enumParameter: 'asyncapi'}), kafkaClient, {fromBeginning: true, groupId: createRandomString(10)});
-          const producer = await produceToSendUserSignedup(invalidMessage, testParameters, kafkaClient);
+          }, parameters: testParameters, kafka: kafkaClient, options: {fromBeginning: true, groupId: createRandomString(10)}});
+          const producer = await produceToSendUserSignedup({message: invalidMessage, parameters: testParameters, kafka: kafkaClient});
           await producer.disconnect();
         }).finally(async () => {
           if (consumer) {
@@ -79,7 +79,7 @@ describe('kafka', () => {
         // eslint-disable-next-line no-async-promise-executor
         let consumer;
         return new Promise<void>(async (resolve, reject) => {
-          consumer = await consumeFromReceiveUserSignedup(async (err, msg, parameters) => {
+          consumer = await consumeFromReceiveUserSignedup({onDataCallback: async (err, msg, parameters) => {
             try {
               expect(err).toBeUndefined();
               expect(msg?.marshal()).toEqual(testMessage.marshal());
@@ -88,8 +88,8 @@ describe('kafka', () => {
             } catch (error) {
               reject(error);
             }
-          }, new UserSignedupParameters({myParameter: 'test', enumParameter: 'asyncapi'}), kafkaClient, {fromBeginning: true, groupId: createRandomString(10)});
-          const producer = await produceToSendUserSignedup(testMessage, testParameters, kafkaClient);
+          }, parameters: testParameters, kafka: kafkaClient, options: {fromBeginning: true, groupId: createRandomString(10)}});
+          const producer = await produceToSendUserSignedup({message: testMessage, parameters: testParameters, kafka: kafkaClient});
           await producer.disconnect();
         }).finally(async () => {
           if (consumer) {
@@ -104,8 +104,8 @@ describe('kafka', () => {
         // eslint-disable-next-line no-async-promise-executor
         let consumer;
         return new Promise<void>(async (resolve, reject) => {
-          consumer = await consumeFromNoParameter(
-            async (err, msg) => {
+          consumer = await consumeFromNoParameter({
+            onDataCallback: async (err, msg) => {
               try {
                 expect(err).toBeUndefined();
                 expect(msg?.marshal()).toEqual(testMessage.marshal());
@@ -114,10 +114,10 @@ describe('kafka', () => {
                 reject(error);
               }
             }, 
-            kafkaClient, 
-            {fromBeginning: true, groupId: createRandomString(10)}
+            kafka: kafkaClient, 
+            options: {fromBeginning: true, groupId: createRandomString(10)}}
           );
-          const producer = await produceToNoParameter(testMessage, kafkaClient);
+          const producer = await produceToNoParameter({message: testMessage, kafka: kafkaClient});
           await producer.disconnect();
         }).finally(async () => {
           if (consumer) {

--- a/test/runtime/typescript/test/channels/kafka.spec.ts
+++ b/test/runtime/typescript/test/channels/kafka.spec.ts
@@ -2,7 +2,7 @@ import { Protocols } from '../../src/channels';
 const { kafka } = Protocols;
 const { 
   produceToNoParameter, consumeFromNoParameter, consumeFromReceiveUserSignedup, produceToSendUserSignedup } = kafka;
-import { Kafka, EachMessagePayload } from 'kafkajs';
+import { Kafka } from 'kafkajs';
 import { UserSignedupParameters } from '../../src/parameters/UserSignedupParameters';
 import { UserSignedUp } from '../../src/payloads/UserSignedUp';
 const kafkaClient = new Kafka({
@@ -10,51 +10,120 @@ const kafkaClient = new Kafka({
   brokers: ['localhost:9093'],
 });
 jest.setTimeout(10000);
+function createRandomString(length) {
+  const chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+  let result = "";
+  for (let i = 0; i < length; i++) {
+    result += chars.charAt(Math.floor(Math.random() * chars.length));
+  }
+  return result;
+}
+
 describe('kafka', () => {
   const testMessage = new UserSignedUp({displayName: 'test', email: 'test@test.dk'});
+  const invalidMessage = new UserSignedUp({displayName: 'test', email: '123'});
   const testParameters = new UserSignedupParameters({myParameter: 'test', enumParameter: 'asyncapi'});
+  const admin = kafkaClient.admin({retry: {retries: 5, initialRetryTime: 1000}});
+  beforeAll(async () => {
+    await admin.connect();
+    await admin.createTopics({
+      topics: [
+        { topic: 'user.signedup.test.asyncapi', numPartitions: 1 },
+        { topic: 'noparameters', numPartitions: 1 },
+      ],
+    });
+  });
+  beforeEach(async() => {
+    try {
+      await admin.deleteTopicRecords({
+        topic: 'user.signedup.test.asyncapi',
+        partitions: [{ partition: 0, offset: '-1' }],
+      });
+      await admin.deleteTopicRecords({
+        topic: 'noparameters',
+        partitions: [{ partition: 0, offset: '-1' }],
+      });
+    } catch (e) {}
+  });
+  afterAll(async () => {
+    await admin.disconnect();
+  });
   describe('channels', () => {
     describe('with parameters', () => {
+      it('should get error on incorrect message', () => {
+        // eslint-disable-next-line no-async-promise-executor
+        let consumer;
+        return new Promise<void>(async (resolve, reject) => {
+          consumer = await consumeFromReceiveUserSignedup(async (err, msg, parameters) => {
+            try {
+              expect(msg).toBeUndefined();
+              expect(err).toBeDefined();
+              expect(err?.message).toEqual('Invalid message payload received');
+              expect(err?.cause).toBeDefined();
+              expect(parameters?.myParameter).toEqual(testParameters.myParameter);
+              resolve();
+            } catch (error) {
+              reject(error);
+            }
+          }, new UserSignedupParameters({myParameter: 'test', enumParameter: 'asyncapi'}), kafkaClient, {fromBeginning: true, groupId: createRandomString(10)});
+          const producer = await produceToSendUserSignedup(invalidMessage, testParameters, kafkaClient);
+          await producer.disconnect();
+        }).finally(async () => {
+          if (consumer) {
+            await consumer.stop();
+            await consumer.disconnect();
+          }
+        });
+      });
       it('should be able to publish and consume', () => {
         // eslint-disable-next-line no-async-promise-executor
+        let consumer;
         return new Promise<void>(async (resolve, reject) => {
-          const consumer = await consumeFromReceiveUserSignedup(async (err, msg: UserSignedUp | undefined, parameters: UserSignedupParameters | undefined, kafkaMsg: EachMessagePayload | undefined) => {
+          consumer = await consumeFromReceiveUserSignedup(async (err, msg, parameters) => {
             try {
               expect(err).toBeUndefined();
               expect(msg?.marshal()).toEqual(testMessage.marshal());
               expect(parameters?.myParameter).toEqual(testParameters.myParameter);
-              await consumer.disconnect();
               resolve();
             } catch (error) {
               reject(error);
-              await consumer.disconnect();
             }
-          }, new UserSignedupParameters({myParameter: 'test', enumParameter: 'asyncapi'}), kafkaClient, {fromBeginning: true, groupId: 'testId1'});
+          }, new UserSignedupParameters({myParameter: 'test', enumParameter: 'asyncapi'}), kafkaClient, {fromBeginning: true, groupId: createRandomString(10)});
           const producer = await produceToSendUserSignedup(testMessage, testParameters, kafkaClient);
           await producer.disconnect();
+        }).finally(async () => {
+          if (consumer) {
+            await consumer.stop();
+            await consumer.disconnect();
+          }
         });
-      });
+      })
     });
     describe('without parameters', () => {
       it('should be able to publish and consume', () => {
         // eslint-disable-next-line no-async-promise-executor
+        let consumer;
         return new Promise<void>(async (resolve, reject) => {
-          const consumer = await consumeFromNoParameter(
+          consumer = await consumeFromNoParameter(
             async (err, msg) => {
               try {
                 expect(err).toBeUndefined();
                 expect(msg?.marshal()).toEqual(testMessage.marshal());
-                await consumer.disconnect();
                 resolve();
               } catch (error) {
                 reject(error);
               }
             }, 
             kafkaClient, 
-            {fromBeginning: true, groupId: 'testId2'}
+            {fromBeginning: true, groupId: createRandomString(10)}
           );
           const producer = await produceToNoParameter(testMessage, kafkaClient);
           await producer.disconnect();
+        }).finally(async () => {
+          if (consumer) {
+            await consumer.stop();
+            await consumer.disconnect();
+          }
         });
       });
     });

--- a/test/runtime/typescript/test/channels/mqtt.spec.ts
+++ b/test/runtime/typescript/test/channels/mqtt.spec.ts
@@ -23,7 +23,7 @@ describe('mqtt', () => {
             client.end();
             resolve();
           });
-          await publishToSendUserSignedup(testMessage, testParameters, client);
+          await publishToSendUserSignedup({message: testMessage, parameters: testParameters, mqtt: client});
         });
       });
     });
@@ -40,7 +40,7 @@ describe('mqtt', () => {
             client.end();
             resolve();
           });
-          await publishToNoParameter(testMessage, client);
+          await publishToNoParameter({message: testMessage, mqtt: client});
         });
       });
     });

--- a/test/runtime/typescript/test/client/nats.spec.ts
+++ b/test/runtime/typescript/test/client/nats.spec.ts
@@ -28,7 +28,7 @@ describe('nats', () => {
       });
 
       it('should be able publish over JetStream', async () => {
-        await client.jetStreamPublishToSendUserSignedup(testMessage, testParameters);
+        await client.jetStreamPublishToSendUserSignedup({message: testMessage, parameters: testParameters});
         const msg = await jsm.streams.getMessage(test_stream, { last_by_subj: test_subj });
         expect(msg.json()).toEqual("{\"display_name\": \"test\",\"email\": \"test@test.dk\"}");
       });
@@ -46,7 +46,7 @@ describe('nats', () => {
               },
             };
             js.publish(`user.signedup.${testParameters.myParameter}.${testParameters.enumParameter}`, testMessage.marshal());
-            const subscriber = await client.jetStreamPullSubscribeToReceiveUserSignedup(async (err, msg, parameters, jetstreamMsg) => {
+            const subscriber = await client.jetStreamPullSubscribeToReceiveUserSignedup({onDataCallback: async (err, msg, parameters, jetstreamMsg) => {
               try {
                 expect(err).toBeUndefined();
                 expect(msg?.marshal()).toEqual(testMessage.marshal());
@@ -57,7 +57,7 @@ describe('nats', () => {
               } catch (error) {
                 reject(error);
               }
-            }, new UserSignedupParameters({ myParameter: '*', enumParameter: 'asyncapi' }), config);
+            }, parameters: new UserSignedupParameters({ myParameter: '*', enumParameter: 'asyncapi' }), options: config});
             subscriber.pull({ batch: 1, expires: 10000 });
           });
         });
@@ -75,7 +75,7 @@ describe('nats', () => {
             };
             const incorrectPayload = JSON.stringify({ displayName: 'test', email: '123' });
             js.publish(`user.signedup.${testParameters.myParameter}.${testParameters.enumParameter}`, incorrectPayload);
-            const subscriber = await client.jetStreamPullSubscribeToReceiveUserSignedup(async (err, _, parameters, jetstreamMsg) => {
+            const subscriber = await client.jetStreamPullSubscribeToReceiveUserSignedup({onDataCallback: async (err, _, parameters, jetstreamMsg) => {
               try {
                 expect(err).toBeDefined();
                 expect(err?.message).toEqual('Invalid message payload received');
@@ -87,7 +87,7 @@ describe('nats', () => {
               } catch (error) {
                 reject(error);
               }
-            }, new UserSignedupParameters({ myParameter: '*', enumParameter: 'asyncapi' }), config);
+            }, parameters: new UserSignedupParameters({ myParameter: '*', enumParameter: 'asyncapi' }), options: config});
             subscriber.pull({ batch: 1, expires: 10000 });
           });
         });
@@ -107,14 +107,14 @@ describe('nats', () => {
               }
             }
           });
-          await client.publishToSendUserSignedup(testMessage, testParameters);
+          await client.publishToSendUserSignedup({message: testMessage, parameters: testParameters});
         });
       });
 
       it('should be able to do core subscribe', () => {
         // eslint-disable-next-line no-async-promise-executor
         return new Promise<void>(async (resolve, reject) => {
-          const subscribtion = await client.subscribeToReceiveUserSignedup(async (err, msg, parameters) => {
+          const subscribtion = await client.subscribeToReceiveUserSignedup({onDataCallback: async (err, msg, parameters) => {
             try {
               expect(err).toBeUndefined();
               expect(msg?.marshal()).toEqual(testMessage.marshal());
@@ -124,7 +124,7 @@ describe('nats', () => {
             } catch (error) {
               reject(error);
             }
-          }, new UserSignedupParameters({ myParameter: '*', enumParameter: 'asyncapi' }));
+          }, parameters: new UserSignedupParameters({ myParameter: '*', enumParameter: 'asyncapi' })});
           nc.publish(`user.signedup.${testParameters.myParameter}.${testParameters.enumParameter}`, testMessage.marshal());
         });
       });
@@ -141,7 +141,7 @@ describe('nats', () => {
           },
         };
         return new Promise<void>(async (resolve, reject) => {
-          const subscription = await client.jetStreamPushSubscriptionFromReceiveUserSignedup(async (err, msg, parameters, jetstreamMsg) => {
+          const subscription = await client.jetStreamPushSubscriptionFromReceiveUserSignedup({onDataCallback: async (err, msg, parameters, jetstreamMsg) => {
             try {
               expect(err).toBeUndefined();
               expect(msg?.marshal()).toEqual(testMessage.marshal());
@@ -152,7 +152,7 @@ describe('nats', () => {
             } catch (error) {
               reject(error);
             }
-          }, new UserSignedupParameters({ myParameter: '*', enumParameter: 'asyncapi' }), config);
+          }, parameters: new UserSignedupParameters({ myParameter: '*', enumParameter: 'asyncapi' }), options: config});
           js.publish(`user.signedup.${testParameters.myParameter}.${testParameters.enumParameter}`, testMessage.marshal());
         });
       });
@@ -179,7 +179,7 @@ describe('nats', () => {
       });
 
       it('should be able publish over JetStream', async () => {
-        await client.jetStreamPublishToNoParameter(testMessage);
+        await client.jetStreamPublishToNoParameter({message: testMessage});
         const msg = await jsm.streams.getMessage(test_stream, { last_by_subj: test_subj });
         expect(msg.json()).toEqual("{\"display_name\": \"test\",\"email\": \"test@test.dk\"}");
       });
@@ -196,7 +196,7 @@ describe('nats', () => {
             },
           };
           js.publish(`noparameters`, testMessage.marshal())
-          const subscriber = await client.jetStreamPullSubscribeToNoParameter(async (err, msg, jetstreamMsg) => {
+          const subscriber = await client.jetStreamPullSubscribeToNoParameter({onDataCallback: async (err, msg, jetstreamMsg) => {
             try {
               expect(err).toBeUndefined();
               expect(msg?.marshal()).toEqual(testMessage.marshal());
@@ -206,7 +206,7 @@ describe('nats', () => {
             } catch (error) {
               reject(error);
             }
-          }, config);
+          }, options: config});
           subscriber.pull({ batch: 1, expires: 10000 });
         });
       });
@@ -225,14 +225,14 @@ describe('nats', () => {
               }
             }
           });
-          await client.publishToNoParameter(testMessage);
+          await client.publishToNoParameter({message: testMessage});
         });
       });
 
       it('should be able to do core subscribe', () => {
         // eslint-disable-next-line no-async-promise-executor
         return new Promise<void>(async (resolve, reject) => {
-          const subscribtion = await client.subscribeToNoParameter(async (err, msg, parameters) => {
+          const subscribtion = await client.subscribeToNoParameter({onDataCallback: async (err, msg, parameters) => {
             try {
               expect(err).toBeUndefined();
               expect(msg?.marshal()).toEqual(testMessage.marshal());
@@ -241,7 +241,7 @@ describe('nats', () => {
             } catch (error) {
               reject(error);
             }
-          });
+          }});
           nc.publish(`noparameters`, testMessage.marshal());
         });
       });
@@ -258,7 +258,7 @@ describe('nats', () => {
           },
         };
         return new Promise<void>(async (resolve, reject) => {
-          const subscription = await client.jetStreamPushSubscriptionFromNoParameter(async (err, msg, jetstreamMsg) => {
+          const subscription = await client.jetStreamPushSubscriptionFromNoParameter({onDataCallback: async (err, msg, jetstreamMsg) => {
             try {
               expect(err).toBeUndefined();
               expect(msg?.marshal()).toEqual(testMessage.marshal());
@@ -268,7 +268,7 @@ describe('nats', () => {
             } catch (error) {
               reject(error);
             }
-          }, config);
+          }, options: config});
           js.publish(`noparameters`, testMessage.marshal());
         });
       });


### PR DESCRIPTION
All function parameters MUST be object parameters to better support many optional parameters without having to write `functionCall(undefined, undefined, 'value')`