### PR TITLE
chore: enable amqp exchange testing in runtime

### DIFF
--- a/test/runtime/typescript/test/channels/regular/amqp.spec.ts
+++ b/test/runtime/typescript/test/channels/regular/amqp.spec.ts
@@ -161,9 +161,22 @@ describe('amqp', () => {
                 if (msg !== null) {
                   const message = UserSignedUp.unmarshal(msg.content.toString());
                   expect(message.marshal()).toEqual(testMessage.marshal());
+                  
+                  // Extract headers the same way the queue consumer does
+                  let extractedHeaders: UserSignedUpHeaders | undefined = undefined;
+                  if (msg.properties && msg.properties.headers) {
+                    const headerObj: Record<string, any> = {};
+                    for (const [key, value] of Object.entries(msg.properties.headers)) {
+                      if (value !== undefined) {
+                        headerObj[key] = value;
+                      }
+                    }
+                    extractedHeaders = UserSignedUpHeaders.unmarshal(headerObj);
+                  }
+                  
                   // Check headers
-                  expect(msg.properties?.headers).toBeDefined();
-                  expect(msg.properties?.headers?.xTestHeader).toEqual('test-header-value');
+                  expect(extractedHeaders).toBeDefined();
+                  expect(extractedHeaders?.xTestHeader).toEqual('test-header-value');
                   channel.ack(msg);
                   resolve();
                 } else {


### PR DESCRIPTION
Re-enable and fix AMQP exchange tests by implementing proper exchange/queue binding and dynamic exchange creation.

The previous AMQP exchange tests were commented out because they used an incorrect AMQP pattern (consuming directly from an exchange) and did not dynamically create the exchange, leading to failures. This PR rewrites the tests to correctly assert exchanges, bind temporary queues, and consume from those queues, ensuring the tests run automatically and correctly.

---
<a href="https://cursor.com/background-agent?bcId=bc-8fd97395-f08d-4545-a550-d34001ca6ce2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8fd97395-f08d-4545-a550-d34001ca6ce2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

