### PR TITLE
chore(release): v0.55.1

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -88,3 +88,4 @@ Get an overview of how to contribute to the project
 
 
 
+

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -172,3 +172,4 @@ Prefix that follows specification is not enough though. Remember that the title 
 
 
 
+

--- a/docs/migrations/v0.md
+++ b/docs/migrations/v0.md
@@ -71,3 +71,4 @@ const subscriber = await jetStreamPullSubscribeToReceiveUserSignedup({
 
 
 
+

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -9,7 +9,7 @@ $ npm install -g @the-codegen-project/cli
 $ codegen COMMAND
 running command...
 $ codegen (--version)
-@the-codegen-project/cli/0.55.0 linux-x64 node-v18.20.8
+@the-codegen-project/cli/0.55.1 linux-x64 node-v18.20.8
 $ codegen --help [COMMAND]
 USAGE
   $ codegen COMMAND
@@ -84,7 +84,7 @@ DESCRIPTION
   Generate code based on your configuration, use `init` to get started.
 ```
 
-_See code: [src/commands/generate.ts](https://github.com/the-codegen-project/cli/blob/v0.55.0/src/commands/generate.ts)_
+_See code: [src/commands/generate.ts](https://github.com/the-codegen-project/cli/blob/v0.55.1/src/commands/generate.ts)_
 
 ## `codegen help [COMMAND]`
 
@@ -142,7 +142,7 @@ DESCRIPTION
   Initialize The Codegen Project in your project
 ```
 
-_See code: [src/commands/init.ts](https://github.com/the-codegen-project/cli/blob/v0.55.0/src/commands/init.ts)_
+_See code: [src/commands/init.ts](https://github.com/the-codegen-project/cli/blob/v0.55.1/src/commands/init.ts)_
 
 ## `codegen version`
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@the-codegen-project/cli",
-  "version": "0.55.0",
+  "version": "0.55.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@the-codegen-project/cli",
-      "version": "0.55.0",
+      "version": "0.55.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@asyncapi/avro-schema-parser": "^3.0.24",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@the-codegen-project/cli",
   "description": "CLI to work with code generation in any environment",
-  "version": "0.55.0",
+  "version": "0.55.1",
   "bin": {
     "codegen": "./bin/run.mjs"
   },

--- a/src/codegen/inputs/asyncapi/generators/parameters.ts
+++ b/src/codegen/inputs/asyncapi/generators/parameters.ts
@@ -81,7 +81,9 @@ export function unwrap(channelParameters: ConstrainedObjectModel) {
   );
 
   const parameterInitializer = Object.values(channelParameters.properties)
-    .filter(parameter => parameter.property.options.const?.value === undefined)
+    .filter(
+      (parameter) => parameter.property.options.const?.value === undefined
+    )
     .map((parameter) => {
       if (parameter.property.options.isNullable) {
         return `${parameter.propertyName}: null`;
@@ -94,8 +96,7 @@ export function unwrap(channelParameters: ConstrainedObjectModel) {
         return `${parameter.propertyName}: ${property.ref.values[0].value}`;
       }
       return `${parameter.propertyName}: ''`;
-    }
-  );
+    });
 
   return `const parameters = new ${channelParameters.name}({${parameterInitializer.join(', ')}});
 const match = msgSubject.match(regex);


### PR DESCRIPTION
Version bump in package.json for release [v0.55.1](https://github.com/the-codegen-project/cli/releases/tag/v0.55.1)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Bumps CLI to 0.55.1, updates docs/version links, and applies minor formatting to the AsyncAPI parameters generator.
> 
> - **Release**
>   - Bump CLI version to `0.55.1` in `package.json` and `package-lock.json`.
> - **Docs**
>   - Update `docs/usage.md` to show version `0.55.1` and refresh “See code” links to `v0.55.1`.
> - **Codegen (AsyncAPI parameters)**
>   - Minor formatting adjustments in `src/codegen/inputs/asyncapi/generators/parameters.ts` (no functional changes).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 54f0e6750da080b3acaf44cc528cdbdb491fa704. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->