### PR TITLE
chore(release): v0.56.0

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -90,3 +90,4 @@ Get an overview of how to contribute to the project
 
 
 
+

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -173,3 +173,4 @@ Prefix that follows specification is not enough though. Remember that the title 
 
 
 
+

--- a/docs/migrations/v0.md
+++ b/docs/migrations/v0.md
@@ -8,6 +8,7 @@ sidebar_position: 99
 - [Migrating between v0](#migrating-between-v0)
   * [Breaking Changes 0.39.0](#breaking-changes-0390)
     + [Functions Parameters](#functions-parameters)
+  * [Breaking Changes 0.55.1](#breaking-changes-0551)
 
 <!-- tocstop -->
 
@@ -61,6 +62,7 @@ const subscriber = await jetStreamPullSubscribeToReceiveUserSignedup({
 ## Breaking Changes 0.55.1
 
 We upgraded the AsyncAPI Modelina dependency to the `next` version so for the next few versions it will contain breaking changes as we continue to improve the tool.
+
 
 
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -9,7 +9,7 @@ $ npm install -g @the-codegen-project/cli
 $ codegen COMMAND
 running command...
 $ codegen (--version)
-@the-codegen-project/cli/0.55.1 linux-x64 node-v18.20.8
+@the-codegen-project/cli/0.56.0 linux-x64 node-v18.20.8
 $ codegen --help [COMMAND]
 USAGE
   $ codegen COMMAND
@@ -84,7 +84,7 @@ DESCRIPTION
   Generate code based on your configuration, use `init` to get started.
 ```
 
-_See code: [src/commands/generate.ts](https://github.com/the-codegen-project/cli/blob/v0.55.1/src/commands/generate.ts)_
+_See code: [src/commands/generate.ts](https://github.com/the-codegen-project/cli/blob/v0.56.0/src/commands/generate.ts)_
 
 ## `codegen help [COMMAND]`
 
@@ -115,6 +115,7 @@ USAGE
   $ codegen init [--help] [--input-file <value>] [--config-name <value>] [--input-type asyncapi|openapi]
     [--output-directory <value>] [--config-type esm|json|yaml|ts] [--languages typescript] [--no-tty]
     [--include-payloads] [--include-headers] [--include-client] [--include-parameters] [--include-channels]
+    [--gitignore-generated]
 
 FLAGS
   --config-name=<value>       [default: codegen] The name to use for the configuration file (dont include file
@@ -123,6 +124,7 @@ FLAGS
                               'yaml' is more restrictive. Read more here:
                               https://github.com/the-codegen-project/cli/blob/main/docs/configurations.md
                               <options: esm|json|yaml|ts>
+  --gitignore-generated       Add generated output directories to .gitignore
   --help                      Show CLI help.
   --include-channels          Include channels generation, available for TypeScript
   --include-client            Include client generation, available for TypeScript
@@ -142,7 +144,7 @@ DESCRIPTION
   Initialize The Codegen Project in your project
 ```
 
-_See code: [src/commands/init.ts](https://github.com/the-codegen-project/cli/blob/v0.55.1/src/commands/init.ts)_
+_See code: [src/commands/init.ts](https://github.com/the-codegen-project/cli/blob/v0.56.0/src/commands/init.ts)_
 
 ## `codegen version`
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@the-codegen-project/cli",
-  "version": "0.55.1",
+  "version": "0.56.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@the-codegen-project/cli",
-      "version": "0.55.1",
+      "version": "0.56.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@asyncapi/avro-schema-parser": "^3.0.24",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@the-codegen-project/cli",
   "description": "CLI to work with code generation in any environment",
-  "version": "0.55.1",
+  "version": "0.56.0",
   "bin": {
     "codegen": "./bin/run.mjs"
   },


### PR DESCRIPTION
Version bump in package.json for release [v0.56.0](https://github.com/the-codegen-project/cli/releases/tag/v0.56.0)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Bumps CLI to 0.56.0 and updates docs, including a new `--gitignore-generated` init flag and migration notes for 0.55.1.
> 
> - **Release**
>   - Bump version to `0.56.0` in `package.json` and `package-lock.json`.
> - **Docs**
>   - Update CLI usage to show `@the-codegen-project/cli/0.56.0`.
>   - Update code links to `v0.56.0` in `docs/usage.md`.
>   - Add `--gitignore-generated` flag to `codegen init` docs with description.
>   - Extend `docs/migrations/v0.md` TOC/content with section for `Breaking Changes 0.55.1`.
>   - Minor whitespace/TOC regeneration in `docs/README.md` and `docs/contributing.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8dac69f0dcb97eeb815f081ea94ef106c4294e19. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->