### PR TITLE
chore(release): v0.56.1

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -91,3 +91,4 @@ Get an overview of how to contribute to the project
 
 
 
+

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -174,3 +174,4 @@ Prefix that follows specification is not enough though. Remember that the title 
 
 
 
+

--- a/docs/migrations/v0.md
+++ b/docs/migrations/v0.md
@@ -75,3 +75,4 @@ We upgraded the AsyncAPI Modelina dependency to the `next` version so for the ne
 
 
 
+

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -9,7 +9,7 @@ $ npm install -g @the-codegen-project/cli
 $ codegen COMMAND
 running command...
 $ codegen (--version)
-@the-codegen-project/cli/0.56.0 linux-x64 node-v18.20.8
+@the-codegen-project/cli/0.56.1 linux-x64 node-v18.20.8
 $ codegen --help [COMMAND]
 USAGE
   $ codegen COMMAND
@@ -84,7 +84,7 @@ DESCRIPTION
   Generate code based on your configuration, use `init` to get started.
 ```
 
-_See code: [src/commands/generate.ts](https://github.com/the-codegen-project/cli/blob/v0.56.0/src/commands/generate.ts)_
+_See code: [src/commands/generate.ts](https://github.com/the-codegen-project/cli/blob/v0.56.1/src/commands/generate.ts)_
 
 ## `codegen help [COMMAND]`
 
@@ -144,7 +144,7 @@ DESCRIPTION
   Initialize The Codegen Project in your project
 ```
 
-_See code: [src/commands/init.ts](https://github.com/the-codegen-project/cli/blob/v0.56.0/src/commands/init.ts)_
+_See code: [src/commands/init.ts](https://github.com/the-codegen-project/cli/blob/v0.56.1/src/commands/init.ts)_
 
 ## `codegen version`
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@the-codegen-project/cli",
-  "version": "0.56.0",
+  "version": "0.56.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@the-codegen-project/cli",
-      "version": "0.56.0",
+      "version": "0.56.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@asyncapi/avro-schema-parser": "^3.0.24",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@the-codegen-project/cli",
   "description": "CLI to work with code generation in any environment",
-  "version": "0.56.0",
+  "version": "0.56.1",
   "bin": {
     "codegen": "./bin/run.mjs"
   },


### PR DESCRIPTION
Version bump in package.json for release [v0.56.1](https://github.com/the-codegen-project/cli/releases/tag/v0.56.1)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Bump CLI to v0.56.1 and update docs to reflect the new version and source links.
> 
> - **Release/version**
>   - Bump CLI to `0.56.1` in `package.json` and `package-lock.json`.
>   - Update docs in `docs/usage.md`:
>     - CLI version output reflects `0.56.1`.
>     - "See code" links point to `v0.56.1` for `generate.ts` and `init.ts`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bc9ee8fc609c9aec6c324a2e58ff3c3b9601c1bc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->