### PR TITLE
chore(release): v0.57.0

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -92,3 +92,4 @@ Get an overview of how to contribute to the project
 
 
 
+

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -175,3 +175,4 @@ Prefix that follows specification is not enough though. Remember that the title 
 
 
 
+

--- a/docs/migrations/v0.md
+++ b/docs/migrations/v0.md
@@ -76,3 +76,4 @@ We upgraded the AsyncAPI Modelina dependency to the `next` version so for the ne
 
 
 
+

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -9,7 +9,7 @@ $ npm install -g @the-codegen-project/cli
 $ codegen COMMAND
 running command...
 $ codegen (--version)
-@the-codegen-project/cli/0.56.1 linux-x64 node-v18.20.8
+@the-codegen-project/cli/0.57.0 linux-x64 node-v18.20.8
 $ codegen --help [COMMAND]
 USAGE
   $ codegen COMMAND
@@ -84,7 +84,7 @@ DESCRIPTION
   Generate code based on your configuration, use `init` to get started.
 ```
 
-_See code: [src/commands/generate.ts](https://github.com/the-codegen-project/cli/blob/v0.56.1/src/commands/generate.ts)_
+_See code: [src/commands/generate.ts](https://github.com/the-codegen-project/cli/blob/v0.57.0/src/commands/generate.ts)_
 
 ## `codegen help [COMMAND]`
 
@@ -144,7 +144,7 @@ DESCRIPTION
   Initialize The Codegen Project in your project
 ```
 
-_See code: [src/commands/init.ts](https://github.com/the-codegen-project/cli/blob/v0.56.1/src/commands/init.ts)_
+_See code: [src/commands/init.ts](https://github.com/the-codegen-project/cli/blob/v0.57.0/src/commands/init.ts)_
 
 ## `codegen version`
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@the-codegen-project/cli",
-  "version": "0.56.1",
+  "version": "0.57.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@the-codegen-project/cli",
-      "version": "0.56.1",
+      "version": "0.57.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@asyncapi/avro-schema-parser": "^3.0.24",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@the-codegen-project/cli",
   "description": "CLI to work with code generation in any environment",
-  "version": "0.56.1",
+  "version": "0.57.0",
   "bin": {
     "codegen": "./bin/run.mjs"
   },

--- a/src/codegen/inputs/asyncapi/generators/types.ts
+++ b/src/codegen/inputs/asyncapi/generators/types.ts
@@ -54,9 +54,11 @@ export async function generateAsyncAPITypes(
   }
 }\n`;
     const topicsMap = `export const TopicsMap: Record<TopicIds, Topics> = {
-${allChannels.map((channel) => {
-  return `  '${channel.id()}': '${channel.address()}'`;
-}).join(', \n')}
+${allChannels
+  .map((channel) => {
+    return `  '${channel.id()}': '${channel.address()}'`;
+  })
+  .join(', \n')}
 };\n`;
     result += topicIdsPart + toTopicIdsPart + toTopicsPart + topicsMap;
   }

--- a/src/codegen/inputs/openapi/generators/types.ts
+++ b/src/codegen/inputs/openapi/generators/types.ts
@@ -98,9 +98,11 @@ export async function generateOpenAPITypes(
 }\n`;
 
     const pathsMap = `export const PathsMap: Record<OperationIds, Paths> = {
-${Object.entries(operationIdToPathMap).map(([operationId, pathStr]) => {
-  return `  '${operationId}': '${pathStr}'`;
-}).join(',\n')}
+${Object.entries(operationIdToPathMap)
+  .map(([operationId, pathStr]) => {
+    return `  '${operationId}': '${pathStr}'`;
+  })
+  .join(',\n')}
 };\n`;
 
     result += toPathPart + toOperationIdsPart + pathsMap;


### PR DESCRIPTION
Version bump in package.json for release [v0.57.0](https://github.com/the-codegen-project/cli/releases/tag/v0.57.0)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Bumps CLI to v0.57.0 and updates docs to reference the new version.
> 
> - **Release**
>   - Bump version to `0.57.0` in `package.json` and `package-lock.json`.
> - **Docs**
>   - Update CLI usage output and "See code" links in `docs/usage.md` to reference `v0.57.0`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 26e55c0572a8d0a25ad26d4284873bbec13bb018. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->