### PR TITLE
chore(release): v0.59.1

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -64,3 +64,4 @@ Get an overview of how to contribute to the project
 Get an overview of how telemetry works for this project
 
 
+

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -178,3 +178,4 @@ Prefix that follows specification is not enough though. Remember that the title 
 
 
 
+

--- a/docs/migrations/v0.md
+++ b/docs/migrations/v0.md
@@ -79,3 +79,4 @@ We upgraded the AsyncAPI Modelina dependency to the `next` version so for the ne
 
 
 
+

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -9,7 +9,7 @@ $ npm install -g @the-codegen-project/cli
 $ codegen COMMAND
 running command...
 $ codegen (--version)
-@the-codegen-project/cli/0.59.0 linux-x64 node-v18.20.8
+@the-codegen-project/cli/0.59.1 linux-x64 node-v18.20.8
 $ codegen --help [COMMAND]
 USAGE
   $ codegen COMMAND
@@ -85,7 +85,7 @@ DESCRIPTION
   Generate code based on your configuration, use `init` to get started.
 ```
 
-_See code: [src/commands/generate.ts](https://github.com/the-codegen-project/cli/blob/v0.59.0/src/commands/generate.ts)_
+_See code: [src/commands/generate.ts](https://github.com/the-codegen-project/cli/blob/v0.59.1/src/commands/generate.ts)_
 
 ## `codegen help [COMMAND]`
 
@@ -145,7 +145,7 @@ DESCRIPTION
   Initialize The Codegen Project in your project
 ```
 
-_See code: [src/commands/init.ts](https://github.com/the-codegen-project/cli/blob/v0.59.0/src/commands/init.ts)_
+_See code: [src/commands/init.ts](https://github.com/the-codegen-project/cli/blob/v0.59.1/src/commands/init.ts)_
 
 ## `codegen telemetry ACTION`
 
@@ -172,7 +172,7 @@ EXAMPLES
   $ codegen telemetry disable
 ```
 
-_See code: [src/commands/telemetry.ts](https://github.com/the-codegen-project/cli/blob/v0.59.0/src/commands/telemetry.ts)_
+_See code: [src/commands/telemetry.ts](https://github.com/the-codegen-project/cli/blob/v0.59.1/src/commands/telemetry.ts)_
 
 ## `codegen version`
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@the-codegen-project/cli",
-  "version": "0.59.0",
+  "version": "0.59.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@the-codegen-project/cli",
-      "version": "0.59.0",
+      "version": "0.59.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@asyncapi/avro-schema-parser": "^3.0.24",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@the-codegen-project/cli",
   "description": "CLI to work with code generation in any environment",
-  "version": "0.59.0",
+  "version": "0.59.1",
   "bin": {
     "codegen": "./bin/run.mjs"
   },


### PR DESCRIPTION
Version bump in package.json for release [v0.59.1](https://github.com/the-codegen-project/cli/releases/tag/v0.59.1)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Bumps CLI to 0.59.1 and updates usage docs and links to reference the new version.
> 
> - **Release**
>   - Bump version to `0.59.1` in `package.json` and `package-lock.json`.
> - **Docs**
>   - Update `docs/usage.md` version output and “See code” links to `v0.59.1`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1ea3447826cb306b3b2f8b97d4a2e0a8adcad29e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->