### PR TITLE
feat: re-add env config properties

### DIFF
--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -139,14 +139,23 @@ Events are still sent to the analytics endpoint in debug mode, but you can see e
 
 ## Custom Tracking Endpoint (for Organizations)
 
-Organizations can point telemetry to their own analytics endpoint:
+Organizations can point telemetry to their own analytics endpoint using environment variables. These environment variables have the **highest priority** and will override any configuration from project-level config or global config files:
 
 ```bash
-# Set custom endpoint
+# Set custom endpoint (highest priority - overrides all other configs)
 export CODEGEN_TELEMETRY_ENDPOINT=https://analytics.mycompany.com/telemetry
 export CODEGEN_TELEMETRY_ID=custom-tracking-id
 export CODEGEN_TELEMETRY_API_SECRET=your-api-secret
 ```
+
+**Configuration Priority Order (highest to lowest):**
+1. **Environment variables** (highest priority):
+   - `CODEGEN_TELEMETRY_DISABLED` / `DO_NOT_TRACK` - disable telemetry
+   - `CODEGEN_TELEMETRY_ENDPOINT` - custom analytics endpoint
+   - `CODEGEN_TELEMETRY_ID` - custom tracking ID
+   - `CODEGEN_TELEMETRY_API_SECRET` - custom API secret
+2. **Project-level config** (from `codegen.config.js`)
+3. **Global config file** (`~/.the-codegen-project/config.json`)
 
 Expected endpoint format (GA4 Measurement Protocol compatible):
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Prioritizes environment variables for telemetry config and adds env overrides for endpoint, tracking ID, and API secret, with updated docs and comprehensive tests.
> 
> - **Telemetry Config (`src/telemetry/config.ts`)**:
>   - Prioritizes environment variables over project and global config.
>   - Applies env overrides for `CODEGEN_TELEMETRY_ENDPOINT`, `CODEGEN_TELEMETRY_ID`, `CODEGEN_TELEMETRY_API_SECRET`; keep disable via `CODEGEN_TELEMETRY_DISABLED`/`DO_NOT_TRACK`.
>   - Extends disabled config to include `apiSecret`.
> - **Tests (`test/telemetry/config.spec.ts`)**:
>   - Adds cases for individual and combined env var overrides and their precedence over project/global config.
>   - Verifies disable precedence via env vars and non-throwing error paths.
> - **Docs (`docs/telemetry.md`)**:
>   - Documents env var priority and configuration order.
>   - Provides env examples for custom endpoint, tracking ID, and API secret.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 17ba8379b0ef3867ab18e95c201b2848559e0476. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->