### PR TITLE
chore(release): v0.60.0

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -66,3 +66,4 @@ Get an overview of how telemetry works for this project
 
 
 
+

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -180,3 +180,4 @@ Prefix that follows specification is not enough though. Remember that the title 
 
 
 
+

--- a/docs/migrations/v0.md
+++ b/docs/migrations/v0.md
@@ -81,3 +81,4 @@ We upgraded the AsyncAPI Modelina dependency to the `next` version so for the ne
 
 
 
+

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -9,7 +9,7 @@ $ npm install -g @the-codegen-project/cli
 $ codegen COMMAND
 running command...
 $ codegen (--version)
-@the-codegen-project/cli/0.59.2 linux-x64 node-v18.20.8
+@the-codegen-project/cli/0.60.0 linux-x64 node-v18.20.8
 $ codegen --help [COMMAND]
 USAGE
   $ codegen COMMAND
@@ -85,7 +85,7 @@ DESCRIPTION
   Generate code based on your configuration, use `init` to get started.
 ```
 
-_See code: [src/commands/generate.ts](https://github.com/the-codegen-project/cli/blob/v0.59.2/src/commands/generate.ts)_
+_See code: [src/commands/generate.ts](https://github.com/the-codegen-project/cli/blob/v0.60.0/src/commands/generate.ts)_
 
 ## `codegen help [COMMAND]`
 
@@ -145,7 +145,7 @@ DESCRIPTION
   Initialize The Codegen Project in your project
 ```
 
-_See code: [src/commands/init.ts](https://github.com/the-codegen-project/cli/blob/v0.59.2/src/commands/init.ts)_
+_See code: [src/commands/init.ts](https://github.com/the-codegen-project/cli/blob/v0.60.0/src/commands/init.ts)_
 
 ## `codegen telemetry ACTION`
 
@@ -172,7 +172,7 @@ EXAMPLES
   $ codegen telemetry disable
 ```
 
-_See code: [src/commands/telemetry.ts](https://github.com/the-codegen-project/cli/blob/v0.59.2/src/commands/telemetry.ts)_
+_See code: [src/commands/telemetry.ts](https://github.com/the-codegen-project/cli/blob/v0.60.0/src/commands/telemetry.ts)_
 
 ## `codegen version`
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@the-codegen-project/cli",
-  "version": "0.59.2",
+  "version": "0.60.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@the-codegen-project/cli",
-      "version": "0.59.2",
+      "version": "0.60.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@asyncapi/avro-schema-parser": "^3.0.24",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@the-codegen-project/cli",
   "description": "CLI to work with code generation in any environment",
-  "version": "0.59.2",
+  "version": "0.60.0",
   "bin": {
     "codegen": "./bin/run.mjs"
   },


### PR DESCRIPTION
Version bump in package.json for release [v0.60.0](https://github.com/the-codegen-project/cli/releases/tag/v0.60.0)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Bumps CLI to 0.60.0 and updates documentation to reference the new version.
> 
> - **Release**
>   - Bump package version to `0.60.0` in `package.json` and `package-lock.json`.
> - **Docs**
>   - Update CLI version output in `docs/usage.md` and refresh "See code" links to `v0.60.0` for `generate`, `init`, and `telemetry` commands.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6c90a16d1b4ae6ca1e9e7b2aea61e1b4d35a533c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->