### PR TITLE
chore(release): v0.62.0

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -68,3 +68,4 @@ Get an overview of how telemetry works for this project
 
 
 
+

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -182,3 +182,4 @@ Prefix that follows specification is not enough though. Remember that the title 
 
 
 
+

--- a/docs/migrations/v0.md
+++ b/docs/migrations/v0.md
@@ -138,3 +138,4 @@ outputPath/
 
 
 
+

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -9,7 +9,7 @@ $ npm install -g @the-codegen-project/cli
 $ codegen COMMAND
 running command...
 $ codegen (--version)
-@the-codegen-project/cli/0.61.0 linux-x64 node-v18.20.8
+@the-codegen-project/cli/0.62.0 linux-x64 node-v18.20.8
 $ codegen --help [COMMAND]
 USAGE
   $ codegen COMMAND
@@ -85,7 +85,7 @@ DESCRIPTION
   Generate code based on your configuration, use `init` to get started.
 ```
 
-_See code: [src/commands/generate.ts](https://github.com/the-codegen-project/cli/blob/v0.61.0/src/commands/generate.ts)_
+_See code: [src/commands/generate.ts](https://github.com/the-codegen-project/cli/blob/v0.62.0/src/commands/generate.ts)_
 
 ## `codegen help [COMMAND]`
 
@@ -145,7 +145,7 @@ DESCRIPTION
   Initialize The Codegen Project in your project
 ```
 
-_See code: [src/commands/init.ts](https://github.com/the-codegen-project/cli/blob/v0.61.0/src/commands/init.ts)_
+_See code: [src/commands/init.ts](https://github.com/the-codegen-project/cli/blob/v0.62.0/src/commands/init.ts)_
 
 ## `codegen telemetry ACTION`
 
@@ -172,7 +172,7 @@ EXAMPLES
   $ codegen telemetry disable
 ```
 
-_See code: [src/commands/telemetry.ts](https://github.com/the-codegen-project/cli/blob/v0.61.0/src/commands/telemetry.ts)_
+_See code: [src/commands/telemetry.ts](https://github.com/the-codegen-project/cli/blob/v0.62.0/src/commands/telemetry.ts)_
 
 ## `codegen version`
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@the-codegen-project/cli",
-  "version": "0.61.0",
+  "version": "0.62.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@the-codegen-project/cli",
-      "version": "0.61.0",
+      "version": "0.62.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@asyncapi/avro-schema-parser": "^3.0.24",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@the-codegen-project/cli",
   "description": "CLI to work with code generation in any environment",
-  "version": "0.61.0",
+  "version": "0.62.0",
   "bin": {
     "codegen": "./bin/run.mjs"
   },


### PR DESCRIPTION
Version bump in package.json for release [v0.62.0](https://github.com/the-codegen-project/cli/releases/tag/v0.62.0)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Release bump to `0.62.0`**
> 
> - Update `package.json` and `package-lock.json` versions to `0.62.0`
> - Refresh `docs/usage.md` to show `@the-codegen-project/cli/0.62.0` and update source links from `v0.61.0` to `v0.62.0`
> - Minor docs whitespace/TOC formatting updates (`docs/README.md`, `docs/contributing.md`, `docs/migrations/v0.md`)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7c7065f1656e8d3b260dc81006c6321329a01292. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->