### PR TITLE
chore(release): v0.63.0

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -66,3 +66,4 @@ Get an overview of how telemetry works for this project
 
 ### [AI Assistants](./ai-assistants.md)
 Connect AI assistants like Claude Code, Cursor, and Windsurf to The Codegen Project via MCP (Model Context Protocol) for intelligent code generation assistance.
+

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -184,3 +184,4 @@ Prefix that follows specification is not enough though. Remember that the title 
 
 
 
+

--- a/docs/migrations/v0.md
+++ b/docs/migrations/v0.md
@@ -140,3 +140,4 @@ outputPath/
 
 
 
+

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -9,7 +9,7 @@ $ npm install -g @the-codegen-project/cli
 $ codegen COMMAND
 running command...
 $ codegen (--version)
-@the-codegen-project/cli/0.62.1 linux-x64 node-v18.20.8
+@the-codegen-project/cli/0.63.0 linux-x64 node-v18.20.8
 $ codegen --help [COMMAND]
 USAGE
   $ codegen COMMAND
@@ -85,7 +85,7 @@ DESCRIPTION
   Generate code based on your configuration, use `init` to get started.
 ```
 
-_See code: [src/commands/generate.ts](https://github.com/the-codegen-project/cli/blob/v0.62.1/src/commands/generate.ts)_
+_See code: [src/commands/generate.ts](https://github.com/the-codegen-project/cli/blob/v0.63.0/src/commands/generate.ts)_
 
 ## `codegen help [COMMAND]`
 
@@ -145,7 +145,7 @@ DESCRIPTION
   Initialize The Codegen Project in your project
 ```
 
-_See code: [src/commands/init.ts](https://github.com/the-codegen-project/cli/blob/v0.62.1/src/commands/init.ts)_
+_See code: [src/commands/init.ts](https://github.com/the-codegen-project/cli/blob/v0.63.0/src/commands/init.ts)_
 
 ## `codegen telemetry ACTION`
 
@@ -172,7 +172,7 @@ EXAMPLES
   $ codegen telemetry disable
 ```
 
-_See code: [src/commands/telemetry.ts](https://github.com/the-codegen-project/cli/blob/v0.62.1/src/commands/telemetry.ts)_
+_See code: [src/commands/telemetry.ts](https://github.com/the-codegen-project/cli/blob/v0.63.0/src/commands/telemetry.ts)_
 
 ## `codegen version`
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@the-codegen-project/cli",
-  "version": "0.62.1",
+  "version": "0.63.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@the-codegen-project/cli",
-      "version": "0.62.1",
+      "version": "0.63.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@asyncapi/avro-schema-parser": "^3.0.24",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@the-codegen-project/cli",
   "description": "CLI to work with code generation in any environment",
-  "version": "0.62.1",
+  "version": "0.63.0",
   "bin": {
     "codegen": "./bin/run.mjs"
   },


### PR DESCRIPTION
Version bump in package.json for release [v0.63.0](https://github.com/the-codegen-project/cli/releases/tag/v0.63.0)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates for the v0.63.0 release.
> 
> - Bump package version to `0.63.0` in `package.json` and `package-lock.json`
> - Refresh docs: update `docs/usage.md` version output and source links for `generate`, `init`, and `telemetry` to point to `v0.63.0`
> - Minor whitespace/toc-related adjustments in docs (`README.md`, `contributing.md`, `migrations/v0.md`)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d83e5542e2c50843269f0af58938c6e034a29efd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->