### PR TITLE
chore(release): v0.64.2

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -70,3 +70,4 @@ Connect AI assistants like Claude Code, Cursor, and Windsurf to The Codegen Proj
 
 
 
+

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -188,3 +188,4 @@ Prefix that follows specification is not enough though. Remember that the title 
 
 
 
+

--- a/docs/migrations/v0.md
+++ b/docs/migrations/v0.md
@@ -11,6 +11,7 @@ sidebar_position: 99
   * [Breaking Changes 0.55.1](#breaking-changes-0551)
   * [Breaking Changes 0.61.0](#breaking-changes-0610)
     + [Channels Multi-File Output](#channels-multi-file-output)
+  * [Breaking Changes 0.64.2](#breaking-changes-0642)
 
 <!-- tocstop -->
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -9,7 +9,7 @@ $ npm install -g @the-codegen-project/cli
 $ codegen COMMAND
 running command...
 $ codegen (--version)
-@the-codegen-project/cli/0.64.1 linux-x64 node-v18.20.8
+@the-codegen-project/cli/0.64.2 linux-x64 node-v22.22.0
 $ codegen --help [COMMAND]
 USAGE
   $ codegen COMMAND
@@ -80,7 +80,7 @@ FLAGS
       --silent    Suppress all output except fatal errors
 ```
 
-_See code: [src/commands/base.ts](https://github.com/the-codegen-project/cli/blob/v0.64.1/src/commands/base.ts)_
+_See code: [src/commands/base.ts](https://github.com/the-codegen-project/cli/blob/v0.64.2/src/commands/base.ts)_
 
 ## `codegen generate [FILE]`
 
@@ -111,7 +111,7 @@ DESCRIPTION
   configuration.
 ```
 
-_See code: [src/commands/generate.ts](https://github.com/the-codegen-project/cli/blob/v0.64.1/src/commands/generate.ts)_
+_See code: [src/commands/generate.ts](https://github.com/the-codegen-project/cli/blob/v0.64.2/src/commands/generate.ts)_
 
 ## `codegen help [COMMAND]`
 
@@ -178,7 +178,7 @@ DESCRIPTION
   Initialize The Codegen Project in your project
 ```
 
-_See code: [src/commands/init.ts](https://github.com/the-codegen-project/cli/blob/v0.64.1/src/commands/init.ts)_
+_See code: [src/commands/init.ts](https://github.com/the-codegen-project/cli/blob/v0.64.2/src/commands/init.ts)_
 
 ## `codegen telemetry ACTION`
 
@@ -211,7 +211,7 @@ EXAMPLES
   $ codegen telemetry disable
 ```
 
-_See code: [src/commands/telemetry.ts](https://github.com/the-codegen-project/cli/blob/v0.64.1/src/commands/telemetry.ts)_
+_See code: [src/commands/telemetry.ts](https://github.com/the-codegen-project/cli/blob/v0.64.2/src/commands/telemetry.ts)_
 
 ## `codegen version`
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@the-codegen-project/cli",
-  "version": "0.64.1",
+  "version": "0.64.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@the-codegen-project/cli",
-      "version": "0.64.1",
+      "version": "0.64.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@asyncapi/avro-schema-parser": "^3.0.24",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@the-codegen-project/cli",
   "description": "CLI to work with code generation in any environment",
-  "version": "0.64.1",
+  "version": "0.64.2",
   "bin": {
     "codegen": "./bin/run.mjs"
   },


### PR DESCRIPTION
Version bump in package.json for release [v0.64.2](https://github.com/the-codegen-project/cli/releases/tag/v0.64.2)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily a version bump and documentation regeneration; behavior changes are limited to consumers needing Node.js v22+.
> 
> **Overview**
> Updates the package version from `0.64.1` to `0.64.2` in `package.json` and `package-lock.json`.
> 
> Refreshes generated docs (`docs/usage.md`, migrations) to reference `v0.64.2`, including noting a **breaking change**: the minimum supported Node.js version is now **v22**.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f0c3521b6a44f358621c7f5ba5878b851a46bb27. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->