### PR TITLE
fix: handle undefined functionTypeMapping in all protocol generators

### DIFF
--- a/src/codegen/generators/typescript/channels/protocols/amqp/index.ts
+++ b/src/codegen/generators/typescript/channels/protocols/amqp/index.ts
@@ -96,7 +96,7 @@ async function generateForOperations(
 ): Promise<SingleFunctionRenderType[]> {
   const renders: SingleFunctionRenderType[] = [];
   const {generator, payloads} = context;
-  const functionTypeMapping = generator.functionTypeMapping[channel.id()];
+  const functionTypeMapping = generator.functionTypeMapping?.[channel.id()];
   const exchangeName = channel.bindings().get('amqp')?.value()?.exchange?.name;
 
   for (const operation of channel.operations().all()) {
@@ -192,7 +192,7 @@ async function generateForChannels(
   const {generator, payloads} = context;
   const functionTypeMapping =
     getFunctionTypeMappingFromAsyncAPI(channel) ??
-    generator.functionTypeMapping[channel.id()];
+    generator.functionTypeMapping?.[channel.id()];
   const exchangeName = channel.bindings().get('amqp')?.value()?.exchange?.name;
 
   const payload = payloads.channelModels[channel.id()];

--- a/src/codegen/generators/typescript/channels/protocols/eventsource/index.ts
+++ b/src/codegen/generators/typescript/channels/protocols/eventsource/index.ts
@@ -97,7 +97,7 @@ async function generateForOperations(
 ): Promise<SingleFunctionRenderType[]> {
   const renders: SingleFunctionRenderType[] = [];
   const {generator, payloads} = context;
-  const functionTypeMapping = generator.functionTypeMapping[channel.id()];
+  const functionTypeMapping = generator.functionTypeMapping?.[channel.id()];
 
   for (const operation of channel.operations().all()) {
     const updatedFunctionTypeMapping =
@@ -188,7 +188,7 @@ async function generateForChannels(
   const {generator, payloads} = context;
   const functionTypeMapping =
     getFunctionTypeMappingFromAsyncAPI(channel) ??
-    generator.functionTypeMapping[channel.id()];
+    generator.functionTypeMapping?.[channel.id()];
 
   const payload = payloads.channelModels[channel.id()];
   if (!payload) {

--- a/src/codegen/generators/typescript/channels/protocols/http/index.ts
+++ b/src/codegen/generators/typescript/channels/protocols/http/index.ts
@@ -110,7 +110,7 @@ function generateForOperations(
 ): HttpRenderType[] {
   const renders: HttpRenderType[] = [];
   const {generator, payloads} = context;
-  const functionTypeMapping = generator.functionTypeMapping[channel.id()];
+  const functionTypeMapping = generator.functionTypeMapping?.[channel.id()];
 
   for (const operation of channel.operations().all()) {
     const updatedFunctionTypeMapping =

--- a/src/codegen/generators/typescript/channels/protocols/kafka/index.ts
+++ b/src/codegen/generators/typescript/channels/protocols/kafka/index.ts
@@ -97,7 +97,7 @@ async function generateForOperations(
 ): Promise<SingleFunctionRenderType[]> {
   const renders: SingleFunctionRenderType[] = [];
   const {generator, payloads} = context;
-  const functionTypeMapping = generator.functionTypeMapping[channel.id()];
+  const functionTypeMapping = generator.functionTypeMapping?.[channel.id()];
 
   for (const operation of channel.operations().all()) {
     const updatedFunctionTypeMapping =
@@ -182,7 +182,7 @@ async function generateForChannels(
   const {generator, payloads} = context;
   const functionTypeMapping =
     getFunctionTypeMappingFromAsyncAPI(channel) ??
-    generator.functionTypeMapping[channel.id()];
+    generator.functionTypeMapping?.[channel.id()];
 
   const payload = payloads.channelModels[channel.id()];
   if (!payload) {

--- a/src/codegen/generators/typescript/channels/protocols/mqtt/index.ts
+++ b/src/codegen/generators/typescript/channels/protocols/mqtt/index.ts
@@ -95,7 +95,7 @@ function generateForOperations(
 ): SingleFunctionRenderType[] {
   const renders: SingleFunctionRenderType[] = [];
   const {generator, payloads} = context;
-  const functionTypeMapping = generator.functionTypeMapping[channel.id()];
+  const functionTypeMapping = generator.functionTypeMapping?.[channel.id()];
 
   for (const operation of channel.operations().all()) {
     const updatedFunctionTypeMapping =
@@ -157,7 +157,7 @@ function generateForChannels(
 ): SingleFunctionRenderType[] {
   const renders: SingleFunctionRenderType[] = [];
   const {generator, payloads} = context;
-  const functionTypeMapping = generator.functionTypeMapping[channel.id()];
+  const functionTypeMapping = generator.functionTypeMapping?.[channel.id()];
 
   const updatedFunctionTypeMapping =
     getFunctionTypeMappingFromAsyncAPI(channel) ?? functionTypeMapping;

--- a/src/codegen/generators/typescript/channels/protocols/nats/index.ts
+++ b/src/codegen/generators/typescript/channels/protocols/nats/index.ts
@@ -112,7 +112,7 @@ async function generateForOperations(
 ): Promise<SingleFunctionRenderType[]> {
   const renders: SingleFunctionRenderType[] = [];
   const {generator, payloads} = context;
-  const functionTypeMapping = generator.functionTypeMapping[channel.id()];
+  const functionTypeMapping = generator.functionTypeMapping?.[channel.id()];
 
   for (const operation of channel.operations().all()) {
     const updatedFunctionTypeMapping =
@@ -325,7 +325,7 @@ async function generateForChannels(
   const {generator, payloads} = context;
   const functionTypeMapping =
     getFunctionTypeMappingFromAsyncAPI(channel) ??
-    generator.functionTypeMapping[channel.id()];
+    generator.functionTypeMapping?.[channel.id()];
 
   const payload = payloads.channelModels[channel.id()];
   if (!payload) {

--- a/src/codegen/generators/typescript/channels/protocols/websocket/index.ts
+++ b/src/codegen/generators/typescript/channels/protocols/websocket/index.ts
@@ -106,7 +106,7 @@ async function generateForOperations(
 ): Promise<SingleFunctionRenderType[]> {
   const renders: SingleFunctionRenderType[] = [];
   const {generator, payloads} = context;
-  const functionTypeMapping = generator.functionTypeMapping[channel.id()];
+  const functionTypeMapping = generator.functionTypeMapping?.[channel.id()];
 
   for (const operation of channel.operations().all()) {
     const updatedFunctionTypeMapping =
@@ -208,7 +208,7 @@ async function generateForChannels(
   const {generator, payloads} = context;
   const functionTypeMapping =
     getFunctionTypeMappingFromAsyncAPI(channel) ??
-    generator.functionTypeMapping[channel.id()];
+    generator.functionTypeMapping?.[channel.id()];
 
   const payload = payloads.channelModels[channel.id()];
   if (!payload) {

--- a/test/codegen/generators/typescript/channels/protocols/functionTypeMapping.spec.ts
+++ b/test/codegen/generators/typescript/channels/protocols/functionTypeMapping.spec.ts
@@ -1,0 +1,274 @@
+/**
+ * Tests that all protocol generators handle undefined functionTypeMapping gracefully.
+ *
+ * Bug: When generator.functionTypeMapping is undefined (instead of {}), accessing
+ * generator.functionTypeMapping[channel.id()] throws:
+ * "Cannot read properties of undefined (reading 'channel_id')"
+ *
+ * This test verifies that all 7 protocol generators have defensive access via optional chaining.
+ */
+import path from 'node:path';
+import {
+  defaultTypeScriptChannelsGenerator,
+  generateTypeScriptChannels,
+  TypeScriptParameterRenderType
+} from '../../../../../../src/codegen/generators';
+import {loadAsyncapiDocument} from '../../../../../../src/codegen/inputs/asyncapi';
+import {
+  ConstrainedAnyModel,
+  ConstrainedObjectModel,
+  OutputModel
+} from '@asyncapi/modelina';
+import {TypeScriptPayloadRenderType} from '../../../../../../src/codegen/generators/typescript/payloads';
+import {TypeScriptHeadersRenderType} from '../../../../../../src/codegen/generators/typescript/headers';
+
+jest.mock('node:fs/promises', () => ({
+  writeFile: jest.fn().mockResolvedValue(undefined),
+  mkdir: jest.fn().mockResolvedValue(undefined)
+}));
+
+describe('functionTypeMapping undefined bug', () => {
+  const payloadModel = new OutputModel(
+    '',
+    new ConstrainedAnyModel('TestPayloadModel', undefined, {}, 'Payload'),
+    'TestPayloadModel',
+    {models: {}, originalInput: undefined},
+    []
+  );
+
+  const createHeadersDependency = (): TypeScriptHeadersRenderType => ({
+    channelModels: {},
+    generator: {outputPath: './test'} as any
+  });
+
+  // Helper to create a generator with functionTypeMapping explicitly set to undefined
+  // This simulates the bug condition where spread operator preserves undefined
+  const createGeneratorWithUndefinedFunctionTypeMapping = (protocols: string[]) => {
+    const generator = {
+      ...defaultTypeScriptChannelsGenerator,
+      outputPath: path.resolve(__dirname, './output'),
+      id: 'test',
+      asyncapiGenerateForOperations: false,
+      protocols
+    };
+    // Explicitly set to undefined to trigger the bug
+    (generator as any).functionTypeMapping = undefined;
+    return generator;
+  };
+
+  let parsedAsyncAPIDocument: any;
+  let parametersDependency: TypeScriptParameterRenderType;
+  let payloadsDependency: TypeScriptPayloadRenderType;
+
+  beforeAll(async () => {
+    parsedAsyncAPIDocument = await loadAsyncapiDocument(
+      path.resolve(__dirname, '../../../../../configs/asyncapi.yaml')
+    );
+
+    const parameterModel = new OutputModel(
+      '',
+      new ConstrainedObjectModel(
+        'TestParameter',
+        undefined,
+        {},
+        'Parameter',
+        {}
+      ),
+      'TestParameter',
+      {models: {}, originalInput: undefined},
+      []
+    );
+
+    parametersDependency = {
+      channelModels: {
+        'user/signedup': parameterModel
+      },
+      generator: {outputPath: './test'} as any
+    };
+
+    payloadsDependency = {
+      channelModels: {
+        'user/signedup': {
+          messageModel: payloadModel,
+          messageType: 'MessageType'
+        }
+      },
+      operationModels: {},
+      otherModels: [],
+      generator: {outputPath: './test'} as any
+    };
+  });
+
+  describe('should handle undefined functionTypeMapping without crashing', () => {
+    it('NATS generator', async () => {
+      await expect(
+        generateTypeScriptChannels({
+          generator: createGeneratorWithUndefinedFunctionTypeMapping(['nats']),
+          inputType: 'asyncapi',
+          asyncapiDocument: parsedAsyncAPIDocument,
+          dependencyOutputs: {
+            'parameters-typescript': parametersDependency,
+            'payloads-typescript': payloadsDependency,
+            'headers-typescript': createHeadersDependency()
+          }
+        })
+      ).resolves.not.toThrow();
+    });
+
+    it('Kafka generator', async () => {
+      await expect(
+        generateTypeScriptChannels({
+          generator: createGeneratorWithUndefinedFunctionTypeMapping(['kafka']),
+          inputType: 'asyncapi',
+          asyncapiDocument: parsedAsyncAPIDocument,
+          dependencyOutputs: {
+            'parameters-typescript': parametersDependency,
+            'payloads-typescript': payloadsDependency,
+            'headers-typescript': createHeadersDependency()
+          }
+        })
+      ).resolves.not.toThrow();
+    });
+
+    it('MQTT generator', async () => {
+      await expect(
+        generateTypeScriptChannels({
+          generator: createGeneratorWithUndefinedFunctionTypeMapping(['mqtt']),
+          inputType: 'asyncapi',
+          asyncapiDocument: parsedAsyncAPIDocument,
+          dependencyOutputs: {
+            'parameters-typescript': parametersDependency,
+            'payloads-typescript': payloadsDependency,
+            'headers-typescript': createHeadersDependency()
+          }
+        })
+      ).resolves.not.toThrow();
+    });
+
+    it('AMQP generator', async () => {
+      await expect(
+        generateTypeScriptChannels({
+          generator: createGeneratorWithUndefinedFunctionTypeMapping(['amqp']),
+          inputType: 'asyncapi',
+          asyncapiDocument: parsedAsyncAPIDocument,
+          dependencyOutputs: {
+            'parameters-typescript': parametersDependency,
+            'payloads-typescript': payloadsDependency,
+            'headers-typescript': createHeadersDependency()
+          }
+        })
+      ).resolves.not.toThrow();
+    });
+
+    it('WebSocket generator', async () => {
+      await expect(
+        generateTypeScriptChannels({
+          generator: createGeneratorWithUndefinedFunctionTypeMapping([
+            'websocket'
+          ]),
+          inputType: 'asyncapi',
+          asyncapiDocument: parsedAsyncAPIDocument,
+          dependencyOutputs: {
+            'parameters-typescript': parametersDependency,
+            'payloads-typescript': payloadsDependency,
+            'headers-typescript': createHeadersDependency()
+          }
+        })
+      ).resolves.not.toThrow();
+    });
+
+    it('EventSource generator', async () => {
+      await expect(
+        generateTypeScriptChannels({
+          generator: createGeneratorWithUndefinedFunctionTypeMapping([
+            'event_source'
+          ]),
+          inputType: 'asyncapi',
+          asyncapiDocument: parsedAsyncAPIDocument,
+          dependencyOutputs: {
+            'parameters-typescript': parametersDependency,
+            'payloads-typescript': payloadsDependency,
+            'headers-typescript': createHeadersDependency()
+          }
+        })
+      ).resolves.not.toThrow();
+    });
+
+    it('HTTP client generator', async () => {
+      // HTTP client needs request/reply pattern, use asyncapi-request.yaml
+      const requestDoc = await loadAsyncapiDocument(
+        path.resolve(__dirname, '../../../../../configs/asyncapi-request.yaml')
+      );
+
+      const httpPayloadsDependency: TypeScriptPayloadRenderType = {
+        channelModels: {
+          ping: {
+            messageModel: payloadModel,
+            messageType: 'MessageType'
+          }
+        },
+        operationModels: {
+          pingRequest: {
+            messageModel: payloadModel,
+            messageType: 'MessageType'
+          },
+          pongResponse: {
+            messageModel: payloadModel,
+            messageType: 'MessageType'
+          },
+          pingRequest_reply: {
+            messageModel: payloadModel,
+            messageType: 'MessageType'
+          }
+        },
+        otherModels: [],
+        generator: {outputPath: './test'} as any
+      };
+
+      const httpGenerator = createGeneratorWithUndefinedFunctionTypeMapping([
+        'http_client'
+      ]);
+      // HTTP requires asyncapiGenerateForOperations: true
+      httpGenerator.asyncapiGenerateForOperations = true;
+
+      await expect(
+        generateTypeScriptChannels({
+          generator: httpGenerator,
+          inputType: 'asyncapi',
+          asyncapiDocument: requestDoc,
+          dependencyOutputs: {
+            'parameters-typescript': {
+              channelModels: {},
+              generator: {outputPath: './test'} as any
+            },
+            'payloads-typescript': httpPayloadsDependency,
+            'headers-typescript': createHeadersDependency()
+          }
+        })
+      ).resolves.not.toThrow();
+    });
+
+    it('all protocols together', async () => {
+      // Test all AsyncAPI-compatible protocols together (excluding http_client which needs special setup)
+      await expect(
+        generateTypeScriptChannels({
+          generator: createGeneratorWithUndefinedFunctionTypeMapping([
+            'nats',
+            'kafka',
+            'mqtt',
+            'amqp',
+            'websocket',
+            'event_source'
+          ]),
+          inputType: 'asyncapi',
+          asyncapiDocument: parsedAsyncAPIDocument,
+          dependencyOutputs: {
+            'parameters-typescript': parametersDependency,
+            'payloads-typescript': payloadsDependency,
+            'headers-typescript': createHeadersDependency()
+          }
+        })
+      ).resolves.not.toThrow();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Fix a crash bug where all protocol generators (NATS, Kafka, MQTT, AMQP, WebSocket, EventSource, HTTP) throw `Cannot read properties of undefined (reading 'channel_id')` when `generator.functionTypeMapping` is `undefined` instead of the expected empty object `{}`.

## Type of Change

- [ ] New feature (adds functionality)
- [x] Bug fix (fixes an issue)
- [ ] Breaking change (changes existing functionality)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)
- [x] Test improvements

## Changes Made

### New Files
- `test/codegen/generators/typescript/channels/protocols/functionTypeMapping.spec.ts` - Unit tests verifying all 7 protocol generators handle undefined `functionTypeMapping` gracefully

### Modified Files
- `src/codegen/generators/typescript/channels/protocols/nats/index.ts` - Added optional chaining at lines 115, 328
- `src/codegen/generators/typescript/channels/protocols/kafka/index.ts` - Added optional chaining at lines 100, 185
- `src/codegen/generators/typescript/channels/protocols/mqtt/index.ts` - Added optional chaining at lines 98, 160
- `src/codegen/generators/typescript/channels/protocols/amqp/index.ts` - Added optional chaining at lines 99, 195
- `src/codegen/generators/typescript/channels/protocols/websocket/index.ts` - Added optional chaining at lines 109, 211
- `src/codegen/generators/typescript/channels/protocols/eventsource/index.ts` - Added optional chaining at lines 100, 191
- `src/codegen/generators/typescript/channels/protocols/http/index.ts` - Added optional chaining at line 113

### Key Implementation Details

#### Root Cause
The bug occurs because:
1. The Zod schema defines `functionTypeMapping` with `.optional().default({})` 
2. This default is applied during Zod parsing
3. However, when `functionTypeMapping: undefined` is explicitly set (not missing), spread operators preserve `undefined`
4. All protocol generators access `generator.functionTypeMapping[channel.id()]` without checking if `functionTypeMapping` exists

#### Fix
Added optional chaining (`?.`) at all 13 access points across 7 protocol generators:

```typescript
// Before (crashes)
const functionTypeMapping = generator.functionTypeMapping[channel.id()];

// After (safe)
const functionTypeMapping = generator.functionTypeMapping?.[channel.id()];
```

## Testing

### Unit Tests (TDD)
✅ Tests written BEFORE implementation and verified to FAIL:
```
TypeError: Cannot read properties of undefined (reading 'user/signedup')
```

✅ Tests PASS after implementation:
```
PASS test/codegen/generators/typescript/channels/protocols/functionTypeMapping.spec.ts
  functionTypeMapping undefined bug
    should handle undefined functionTypeMapping without crashing
      ✓ NATS generator (6 ms)
      ✓ Kafka generator (1 ms)
      ✓ MQTT generator (1 ms)
      ✓ AMQP generator
      ✓ WebSocket generator
      ✓ EventSource generator
      ✓ HTTP client generator (7 ms)
      ✓ all protocols together (1 ms)

Test Suites: 1 passed, 1 total
Tests:       8 passed, 8 total
```

### Full Test Suite
✅ All unit tests pass: `npm run test`

### Build
✅ Build succeeds: `npm run build`

### Lint
✅ Lint passes: `npm run lint`

### Runtime Generate
✅ Runtime code generates successfully: `npm run runtime:typescript:generate`

## Breaking Changes

**None** - This is a purely additive defensive fix using optional chaining. Existing behavior is unchanged for valid configurations.

## Checklist

- [x] Code follows project conventions
- [x] All tests pass (unit, blackbox, runtime)
- [x] No TypeScript errors
- [x] Lint passes
- [x] Build succeeds
- [x] Follows existing patterns
- [x] Tests verify the bug existed and is now fixed (TDD)

## Verification

After implementation, verified no unguarded access remains:
```bash
# Should return 0 results (no unguarded access)
rg "generator\.functionTypeMapping\[" src/codegen/generators/typescript/channels/protocols/
# Result: No matches found ✓

# Should show 13 guarded accesses
rg "generator\.functionTypeMapping\?\.\[" src/codegen/generators/typescript/channels/protocols/
# Result: 13 matches ✓
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small defensive change (optional chaining) in TypeScript channel codegen; main risk is minor behavior change in how default function-type filtering is applied when the mapping is missing/undefined.
> 
> **Overview**
> Prevents crashes in the TypeScript channels codegen when `generator.functionTypeMapping` is explicitly `undefined` by switching all protocol generators (AMQP, EventSource, HTTP client, Kafka, MQTT, NATS, WebSocket) to use optional-chained lookups (`generator.functionTypeMapping?.[channel.id()]`).
> 
> Adds a Jest regression test that runs `generateTypeScriptChannels` across each protocol (and a combined run) with `functionTypeMapping` forced to `undefined`, asserting generation completes without throwing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7984353d699e89cab5af32edf0e88a20d2129d02. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->