### PR TITLE
fix: generate clean OpenAPI operation names without duplicated HTTP verb

### DIFF
--- a/src/codegen/generators/typescript/channels/openapi.ts
+++ b/src/codegen/generators/typescript/channels/openapi.ts
@@ -15,10 +15,11 @@ import {ConstrainedObjectModel} from '@asyncapi/modelina';
 import {collectProtocolDependencies} from './utils';
 import {renderHttpFetchClient, renderHttpCommonTypes} from './protocols/http';
 import {getMessageTypeAndModule} from './utils';
-import {pascalCase} from '../utils';
+import {camelCase} from '../utils';
 import {createMissingInputDocumentError} from '../../../errors';
 import {resolveImportExtension} from '../../../utils';
 import {extractSecuritySchemes} from '../../../inputs/openapi/security';
+import {deriveOperationId} from '../../../inputs/openapi/utils';
 
 type OpenAPIDocument =
   | OpenAPIV3.Document
@@ -172,7 +173,11 @@ function processOperation(
     return undefined;
   }
 
-  const operationId = getOperationId(operation, method, path);
+  const operationId = deriveOperationId({
+    operationId: operation.operationId,
+    method,
+    path
+  });
   const hasBody = METHODS_WITH_BODY.includes(method);
 
   // Look up payloads
@@ -221,9 +226,12 @@ function processOperation(
   const description = operation.description ?? operation.summary;
   const deprecated = operation.deprecated === true;
 
-  // Generate the HTTP client function
+  // Generate the HTTP client function.
+  // Use the operationId directly as the function name; the HTTP method is
+  // already encoded in synthesized ids (and meaningful in spec-provided ones),
+  // so prepending the method here would double the verb (e.g. getGetUser).
   return renderHttpFetchClient({
-    subName: pascalCase(operationId),
+    functionName: camelCase(operationId),
     requestMessageModule: hasBody ? requestMessageModule : undefined,
     requestMessageType: hasBody ? requestMessageType : undefined,
     replyMessageModule,
@@ -266,21 +274,4 @@ function validateOpenAPIContext(context: TypeScriptChannelsContext): {
     });
   }
   return {openapiDocument};
-}
-
-/**
- * Gets the operation ID from an OpenAPI operation.
- * Falls back to generating one from method+path if not present.
- */
-function getOperationId(
-  operation: OpenAPIOperation,
-  method: string,
-  path: string
-): string {
-  if (operation.operationId) {
-    return operation.operationId;
-  }
-  // Generate from method + path
-  const sanitizedPath = path.replace(/[^a-zA-Z0-9]/g, '');
-  return `${method}${sanitizedPath}`;
 }

--- a/src/codegen/inputs/openapi/generators/headers.ts
+++ b/src/codegen/inputs/openapi/generators/headers.ts
@@ -2,6 +2,7 @@
 import {OpenAPIV2, OpenAPIV3, OpenAPIV3_1} from 'openapi-types';
 import {ProcessedHeadersData} from '../../../generators/typescript/headers';
 import {pascalCase} from '../../../generators/typescript/utils';
+import {deriveOperationId} from '../utils';
 
 // Helper function to convert OpenAPI header schema to JSON Schema
 function convertHeaderSchemaToJsonSchema(header: any): any {
@@ -54,9 +55,11 @@ function extractHeadersFromOperations(
       });
 
       if (allParameters.length > 0) {
-        const operationId =
-          operationObj.operationId ??
-          `${method}${pathKey.replace(/[^a-zA-Z0-9]/g, '')}`;
+        const operationId = deriveOperationId({
+          operationId: operationObj.operationId,
+          method,
+          path: pathKey
+        });
         operationHeaders[operationId] = headerParams;
       }
     }

--- a/src/codegen/inputs/openapi/generators/parameters.ts
+++ b/src/codegen/inputs/openapi/generators/parameters.ts
@@ -5,6 +5,7 @@ import {
   pascalCase
 } from '../../../generators/typescript/utils';
 import {ProcessedParameterSchemaData} from '../../asyncapi/generators/parameters';
+import {deriveOperationId} from '../utils';
 import {
   ConstrainedObjectModel,
   TS_DESCRIPTION_PRESET,
@@ -78,9 +79,11 @@ export function processOpenAPIParameters(
       });
 
       if (filteredParams.length > 0) {
-        const operationId =
-          operationObj.operationId ??
-          `${method}${pathKey.replace(/[^a-zA-Z0-9]/g, '')}`;
+        const operationId = deriveOperationId({
+          operationId: operationObj.operationId,
+          method,
+          path: pathKey
+        });
         // Create schema for the parameters
         const parameterSchema = createParameterSchema(
           operationId,

--- a/src/codegen/inputs/openapi/generators/payloads.ts
+++ b/src/codegen/inputs/openapi/generators/payloads.ts
@@ -4,6 +4,7 @@ import {OpenAPIV2, OpenAPIV3, OpenAPIV3_1} from 'openapi-types';
 import {ProcessedPayloadSchemaData} from '../../asyncapi/generators/payloads';
 import {pascalCase} from '../../../generators/typescript/utils';
 import {onlyUnique} from '../../../utils';
+import {deriveOperationId} from '../utils';
 
 // Constants
 const JSON_SCHEMA_DRAFT_07 = 'http://json-schema.org/draft-07/schema';
@@ -145,9 +146,11 @@ function extractPayloadsFromOperations(
         | OpenAPIV2.OperationObject
         | OpenAPIV3_1.OperationObject;
 
-      const operationId =
-        operationObj.operationId ??
-        `${method}${pathKey.replace(/[^a-zA-Z0-9]/g, '')}`;
+      const operationId = deriveOperationId({
+        operationId: operationObj.operationId,
+        method,
+        path: pathKey
+      });
 
       // Extract request payload schema
       let requestSchema: any = null;

--- a/src/codegen/inputs/openapi/generators/types.ts
+++ b/src/codegen/inputs/openapi/generators/types.ts
@@ -2,6 +2,7 @@
 import {OpenAPIV2, OpenAPIV3, OpenAPIV3_1} from 'openapi-types';
 import {TypescriptTypesGeneratorInternal} from '../../../generators/typescript/types';
 import {GeneratedFile} from '../../../types';
+import {deriveOperationId} from '../utils';
 
 export interface TypesGeneratorResult {
   result: string;
@@ -47,9 +48,11 @@ export async function generateOpenAPITypes(
         typeof operationObj === 'object' &&
         method !== 'parameters'
       ) {
-        const operationId =
-          operationObj.operationId ??
-          `${method}${pathStr.replace(/[^a-zA-Z0-9]/g, '')}`;
+        const operationId = deriveOperationId({
+          operationId: operationObj.operationId,
+          method,
+          path: pathStr
+        });
         operationIds.push(operationId);
         operationIdToPathMap[operationId] = pathStr;
         pathOperationIds.push(operationId);

--- a/src/codegen/inputs/openapi/utils.ts
+++ b/src/codegen/inputs/openapi/utils.ts
@@ -1,0 +1,33 @@
+/**
+ * Shared helpers for deriving stable identifiers from OpenAPI operations.
+ */
+import {FormatHelpers} from '@asyncapi/modelina';
+
+/**
+ * Derive the operation identifier used to correlate payloads, parameters,
+ * headers and channel functions for a single OpenAPI operation.
+ *
+ * When the spec provides an `operationId` it is used verbatim so generated
+ * names stay predictable. Otherwise a name is synthesized from the HTTP method
+ * and path segments, preserving word boundaries so it can be cased cleanly
+ * (e.g. `GET /v2/connect/{referenceId}` -> `getV2ConnectReferenceId`) instead
+ * of collapsing into an uncasable blob (`getv2connectreferenceId`).
+ */
+export function deriveOperationId({
+  operationId,
+  method,
+  path
+}: {
+  operationId?: string;
+  method: string;
+  path: string;
+}): string {
+  if (operationId) {
+    return operationId;
+  }
+  const segments = path
+    .split('/')
+    .map((segment) => segment.replace(/[{}]/g, ''))
+    .filter((segment) => segment.length > 0);
+  return FormatHelpers.toCamelCase([method, ...segments].join(' '));
+}

--- a/test/codegen/generators/typescript/__snapshots__/channels.spec.ts.snap
+++ b/test/codegen/generators/typescript/__snapshots__/channels.spec.ts.snap
@@ -998,7 +998,7 @@ async function handleTokenRefresh(
 // Generated HTTP Client Functions
 // ============================================================================
 
-export interface PostAddPetContext extends HttpClientContext {
+export interface AddPetContext extends HttpClientContext {
   payload: Pet;
   requestHeaders?: { marshal: () => string };
 }
@@ -1006,7 +1006,7 @@ export interface PostAddPetContext extends HttpClientContext {
 /**
  * HTTP POST request to /pet
  */
-async function postAddPet(context: PostAddPetContext): Promise<HttpClientResponse<Pet>> {
+async function addPet(context: AddPetContext): Promise<HttpClientResponse<Pet>> {
   // Apply defaults
   const config = {
     path: '/pet',
@@ -1107,7 +1107,7 @@ async function postAddPet(context: PostAddPetContext): Promise<HttpClientRespons
       headers: responseHeaders,
       rawData,
       pagination: paginationInfo,
-      ...createPaginationHelpers(config, paginationInfo, postAddPet),
+      ...createPaginationHelpers(config, paginationInfo, addPet),
     };
 
     return result;
@@ -1121,7 +1121,7 @@ async function postAddPet(context: PostAddPetContext): Promise<HttpClientRespons
   }
 }
 
-export interface PutUpdatePetContext extends HttpClientContext {
+export interface UpdatePetContext extends HttpClientContext {
   payload: Pet;
   requestHeaders?: { marshal: () => string };
 }
@@ -1129,7 +1129,7 @@ export interface PutUpdatePetContext extends HttpClientContext {
 /**
  * HTTP PUT request to /pet
  */
-async function putUpdatePet(context: PutUpdatePetContext): Promise<HttpClientResponse<Pet>> {
+async function updatePet(context: UpdatePetContext): Promise<HttpClientResponse<Pet>> {
   // Apply defaults
   const config = {
     path: '/pet',
@@ -1230,7 +1230,7 @@ async function putUpdatePet(context: PutUpdatePetContext): Promise<HttpClientRes
       headers: responseHeaders,
       rawData,
       pagination: paginationInfo,
-      ...createPaginationHelpers(config, paginationInfo, putUpdatePet),
+      ...createPaginationHelpers(config, paginationInfo, updatePet),
     };
 
     return result;
@@ -1244,7 +1244,7 @@ async function putUpdatePet(context: PutUpdatePetContext): Promise<HttpClientRes
   }
 }
 
-export interface GetFindPetsByStatusAndCategoryContext extends HttpClientContext {
+export interface FindPetsByStatusAndCategoryContext extends HttpClientContext {
   parameters: { getChannelWithParameters: (path: string) => string };
   requestHeaders?: { marshal: () => string };
 }
@@ -1252,7 +1252,7 @@ export interface GetFindPetsByStatusAndCategoryContext extends HttpClientContext
 /**
  * Find pets by status and category with additional filtering options
  */
-async function getFindPetsByStatusAndCategory(context: GetFindPetsByStatusAndCategoryContext): Promise<HttpClientResponse<FindPetsByStatusAndCategoryResponseModule.Pet[]>> {
+async function findPetsByStatusAndCategory(context: FindPetsByStatusAndCategoryContext): Promise<HttpClientResponse<FindPetsByStatusAndCategoryResponseModule.Pet[]>> {
   // Apply defaults
   const config = {
     path: '/pet/findByStatus/{status}/{categoryId}',
@@ -1353,7 +1353,7 @@ async function getFindPetsByStatusAndCategory(context: GetFindPetsByStatusAndCat
       headers: responseHeaders,
       rawData,
       pagination: paginationInfo,
-      ...createPaginationHelpers(config, paginationInfo, getFindPetsByStatusAndCategory),
+      ...createPaginationHelpers(config, paginationInfo, findPetsByStatusAndCategory),
     };
 
     return result;
@@ -1367,7 +1367,7 @@ async function getFindPetsByStatusAndCategory(context: GetFindPetsByStatusAndCat
   }
 }
 
-export { postAddPet, putUpdatePet, getFindPetsByStatusAndCategory };
+export { addPet, updatePet, findPetsByStatusAndCategory };
 "
 `;
 

--- a/test/codegen/inputs/openapi/utils.spec.ts
+++ b/test/codegen/inputs/openapi/utils.spec.ts
@@ -1,0 +1,39 @@
+import {deriveOperationId} from '../../../../src/codegen/inputs/openapi/utils';
+
+describe('OpenAPI operation id derivation', () => {
+  describe('deriveOperationId', () => {
+    it('uses a spec-provided operationId verbatim', () => {
+      expect(
+        deriveOperationId({
+          operationId: 'findPetsByStatus',
+          method: 'get',
+          path: '/pet/findByStatus'
+        })
+      ).toEqual('findPetsByStatus');
+    });
+
+    it('synthesizes a clean camelCase name from method and path', () => {
+      expect(
+        deriveOperationId({
+          method: 'get',
+          path: '/v2/connect/{referenceId}'
+        })
+      ).toEqual('getV2ConnectReferenceId');
+    });
+
+    it('preserves word boundaries across kebab-case path segments', () => {
+      expect(
+        deriveOperationId({
+          method: 'post',
+          path: '/v2/users/{safepayAccountId}/bank-accounts/add'
+        })
+      ).toEqual('postV2UsersSafepayAccountIdBankAccountsAdd');
+    });
+
+    it('does not double the HTTP verb when synthesizing', () => {
+      const id = deriveOperationId({method: 'get', path: '/v2/users'});
+      expect(id).toEqual('getV2Users');
+      expect(id).not.toMatch(/getGet/i);
+    });
+  });
+});

--- a/test/runtime/typescript/src/openapi/channels/http_client.ts
+++ b/test/runtime/typescript/src/openapi/channels/http_client.ts
@@ -996,7 +996,7 @@ async function handleTokenRefresh(
 // Generated HTTP Client Functions
 // ============================================================================
 
-export interface PostAddPetContext extends HttpClientContext {
+export interface AddPetContext extends HttpClientContext {
   payload: APet;
   requestHeaders?: { marshal: () => string };
 }
@@ -1004,7 +1004,7 @@ export interface PostAddPetContext extends HttpClientContext {
 /**
  * HTTP POST request to /pet
  */
-async function postAddPet(context: PostAddPetContext): Promise<HttpClientResponse<APet>> {
+async function addPet(context: AddPetContext): Promise<HttpClientResponse<APet>> {
   // Apply defaults
   const config = {
     path: '/pet',
@@ -1105,7 +1105,7 @@ async function postAddPet(context: PostAddPetContext): Promise<HttpClientRespons
       headers: responseHeaders,
       rawData,
       pagination: paginationInfo,
-      ...createPaginationHelpers(config, paginationInfo, postAddPet),
+      ...createPaginationHelpers(config, paginationInfo, addPet),
     };
 
     return result;
@@ -1119,7 +1119,7 @@ async function postAddPet(context: PostAddPetContext): Promise<HttpClientRespons
   }
 }
 
-export interface PutUpdatePetContext extends HttpClientContext {
+export interface UpdatePetContext extends HttpClientContext {
   payload: APet;
   requestHeaders?: { marshal: () => string };
 }
@@ -1127,7 +1127,7 @@ export interface PutUpdatePetContext extends HttpClientContext {
 /**
  * HTTP PUT request to /pet
  */
-async function putUpdatePet(context: PutUpdatePetContext): Promise<HttpClientResponse<APet>> {
+async function updatePet(context: UpdatePetContext): Promise<HttpClientResponse<APet>> {
   // Apply defaults
   const config = {
     path: '/pet',
@@ -1228,7 +1228,7 @@ async function putUpdatePet(context: PutUpdatePetContext): Promise<HttpClientRes
       headers: responseHeaders,
       rawData,
       pagination: paginationInfo,
-      ...createPaginationHelpers(config, paginationInfo, putUpdatePet),
+      ...createPaginationHelpers(config, paginationInfo, updatePet),
     };
 
     return result;
@@ -1242,7 +1242,7 @@ async function putUpdatePet(context: PutUpdatePetContext): Promise<HttpClientRes
   }
 }
 
-export interface GetFindPetsByStatusAndCategoryContext extends HttpClientContext {
+export interface FindPetsByStatusAndCategoryContext extends HttpClientContext {
   parameters: { getChannelWithParameters: (path: string) => string };
   requestHeaders?: { marshal: () => string };
 }
@@ -1250,7 +1250,7 @@ export interface GetFindPetsByStatusAndCategoryContext extends HttpClientContext
 /**
  * Find pets by status and category with additional filtering options
  */
-async function getFindPetsByStatusAndCategory(context: GetFindPetsByStatusAndCategoryContext): Promise<HttpClientResponse<FindPetsByStatusAndCategoryResponse_200Module.FindPetsByStatusAndCategoryResponse_200>> {
+async function findPetsByStatusAndCategory(context: FindPetsByStatusAndCategoryContext): Promise<HttpClientResponse<FindPetsByStatusAndCategoryResponse_200Module.FindPetsByStatusAndCategoryResponse_200>> {
   // Apply defaults
   const config = {
     path: '/pet/findByStatus/{status}/{categoryId}',
@@ -1351,7 +1351,7 @@ async function getFindPetsByStatusAndCategory(context: GetFindPetsByStatusAndCat
       headers: responseHeaders,
       rawData,
       pagination: paginationInfo,
-      ...createPaginationHelpers(config, paginationInfo, getFindPetsByStatusAndCategory),
+      ...createPaginationHelpers(config, paginationInfo, findPetsByStatusAndCategory),
     };
 
     return result;
@@ -1365,4 +1365,4 @@ async function getFindPetsByStatusAndCategory(context: GetFindPetsByStatusAndCat
   }
 }
 
-export { postAddPet, putUpdatePet, getFindPetsByStatusAndCategory };
+export { addPet, updatePet, findPetsByStatusAndCategory };

--- a/test/runtime/typescript/test/channels/request_reply/http_client/openapi.spec.ts
+++ b/test/runtime/typescript/test/channels/request_reply/http_client/openapi.spec.ts
@@ -1,9 +1,9 @@
 /* eslint-disable no-console */
 import { createTestServer, runWithServer } from './test-utils';
 import {
-  postAddPet,
-  putUpdatePet,
-  getFindPetsByStatusAndCategory,
+  addPet,
+  updatePet,
+  findPetsByStatusAndCategory,
 } from '../../../../src/openapi/channels/http_client';
 import { APet } from '../../../../src/openapi/payloads/APet';
 import { FindPetsByStatusAndCategoryParameters } from '../../../../src/openapi/parameters/FindPetsByStatusAndCategoryParameters';
@@ -27,7 +27,7 @@ describe('HTTP Client - OpenAPI Generated', () => {
       });
 
       return runWithServer(app, port, async (_server, actualPort) => {
-        const response = await postAddPet({
+        const response = await addPet({
           payload: requestPet,
           server: `http://localhost:${actualPort}`
         });
@@ -56,7 +56,7 @@ describe('HTTP Client - OpenAPI Generated', () => {
       });
 
       return runWithServer(app, port, async (_server, actualPort) => {
-        const response = await putUpdatePet({
+        const response = await updatePet({
           payload: requestPet,
           server: `http://localhost:${actualPort}`
         });
@@ -88,7 +88,7 @@ describe('HTTP Client - OpenAPI Generated', () => {
           categoryId: 123
         });
 
-        const response = await getFindPetsByStatusAndCategory({
+        const response = await findPetsByStatusAndCategory({
           parameters: params,
           server: `http://localhost:${actualPort}`
         });
@@ -110,7 +110,7 @@ describe('HTTP Client - OpenAPI Generated', () => {
 
       return runWithServer(app, port, async (_server, actualPort) => {
         const pet = new APet({ name: 'Test', photoUrls: [] });
-        await expect(postAddPet({
+        await expect(addPet({
           payload: pet,
           server: `http://localhost:${actualPort}`
         })).rejects.toThrow();
@@ -130,7 +130,7 @@ describe('HTTP Client - OpenAPI Generated', () => {
           categoryId: 999
         });
 
-        await expect(getFindPetsByStatusAndCategory({
+        await expect(findPetsByStatusAndCategory({
           parameters: params,
           server: `http://localhost:${actualPort}`
         })).rejects.toThrow('Not Found');

--- a/test/runtime/typescript/test/channels/request_reply/http_client/security_schemes.spec.ts
+++ b/test/runtime/typescript/test/channels/request_reply/http_client/security_schemes.spec.ts
@@ -11,7 +11,7 @@
 import {createTestServer, runWithServer} from './test-utils';
 import {APet} from '../../../../src/openapi/payloads/APet';
 import {
-  postAddPet
+  addPet
 } from '../../../../src/openapi/channels/http_client';
 
 // Type-level test: Verify AuthConfig is narrowed to only defined types
@@ -82,7 +82,7 @@ describe('HTTP Client - Security Schemes from OpenAPI', () => {
 
         // Use apiKey auth - users need to provide name/in but the defaults
         // from the spec are documented in the generated interface
-        await postAddPet({
+        await addPet({
           payload: requestPet,
           server: `http://localhost:${actualPort}`,
           auth: {
@@ -121,7 +121,7 @@ describe('HTTP Client - Security Schemes from OpenAPI', () => {
         });
 
         // Use the header name from the spec
-        await postAddPet({
+        await addPet({
           payload: requestPet,
           server: `http://localhost:${actualPort}`,
           auth: {
@@ -160,7 +160,7 @@ describe('HTTP Client - Security Schemes from OpenAPI', () => {
         });
 
         // With a pre-obtained token, oauth2 works
-        const response = await postAddPet({
+        const response = await addPet({
           payload: requestPet,
           server: `http://localhost:${actualPort}`,
           auth: {
@@ -196,7 +196,7 @@ describe('HTTP Client - Security Schemes from OpenAPI', () => {
 
         // The spec defines scopes: write:pets, read:pets
         // The generated interface documents these in the JSDoc
-        await postAddPet({
+        await addPet({
           payload: requestPet,
           server: `http://localhost:${actualPort}`,
           auth: {
@@ -217,13 +217,13 @@ describe('HTTP Client - Security Schemes from OpenAPI', () => {
       //
       // The following commented code would cause a TypeScript error:
       //
-      // await postAddPet({
+      // await addPet({
       //   payload: requestPet,
       //   server: `http://localhost:${actualPort}`,
       //   auth: { type: 'basic', username: 'user', password: 'pass' } // TypeScript Error!
       // });
       //
-      // await postAddPet({
+      // await addPet({
       //   payload: requestPet,
       //   server: `http://localhost:${actualPort}`,
       //   auth: { type: 'bearer', token: 'token' } // TypeScript Error!


### PR DESCRIPTION
## Problem

Generated HTTP client function names for OpenAPI inputs duplicated the HTTP verb and, for specs without `operationId`s, collapsed into uncasable blobs.

- `GET /v2/connect/{referenceId}` (no operationId) → `getGetv2connectreferenceId`
- A real `operationId: findPetsByStatusAndCategory` on GET → `getFindPetsByStatusAndCategory`

Two causes:
1. The channel generator **always prepended the HTTP method** to the pascal-cased operationId, even though the operationId already encodes/represents the verb.
2. The synthesized operationId (`${method}${path.replace(/[^a-zA-Z0-9]/g,'')}`) stripped **all** separators, destroying word boundaries so casing could never be recovered.

## Fix

- Extract a shared `deriveOperationId({operationId, method, path})` helper: spec-provided ids are used verbatim; synthesized ids are built from method + path segments with word boundaries preserved (`getV2ConnectReferenceId`).
- Use it across payloads, parameters, types, headers **and** the channel generator so the correlation key stays consistent.
- Stop re-prepending the method in the channel function name.

## Result

`GET /v2/connect/{referenceId}` → `getV2ConnectReferenceId`; `findPetsByStatusAndCategory` stays `findPetsByStatusAndCategory`.

## Tests

- New `test/codegen/inputs/openapi/utils.spec.ts` covering verbatim ids, synthesis, kebab segments, and the no-double-verb guarantee.
- Updated channels snapshot (names only).

> Note: this changes the names in generated OpenAPI output (function names, `OperationIds` union, schema `$id`s) — intended, and strictly an improvement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)