### PR TITLE
fix: only generate auth handling for schemes the spec defines

### DIFF
--- a/src/codegen/generators/typescript/channels/openapi.ts
+++ b/src/codegen/generators/typescript/channels/openapi.ts
@@ -13,7 +13,11 @@ import {
 } from './types';
 import {ConstrainedObjectModel} from '@asyncapi/modelina';
 import {collectProtocolDependencies} from './utils';
-import {renderHttpFetchClient, renderHttpCommonTypes} from './protocols/http';
+import {
+  renderHttpFetchClient,
+  renderHttpCommonTypes,
+  analyzeSecuritySchemes
+} from './protocols/http';
 import {getMessageTypeAndModule} from './utils';
 import {camelCase} from '../utils';
 import {createMissingInputDocumentError} from '../../../errors';
@@ -92,11 +96,17 @@ export async function generateTypeScriptChannelsForOpenAPI(
     importExtension
   );
 
+  // OAuth2 request handling is only generated when the spec defines an OAuth2
+  // scheme; otherwise the narrowed AuthConfig union would make that code fail to
+  // type-check.
+  const oauth2Enabled = analyzeSecuritySchemes(securitySchemes).oauth2;
+
   // Process all operations and collect renders
   const renders = processOpenAPIOperations(
     openapiDocument,
     payloads,
-    parameters
+    parameters,
+    oauth2Enabled
   );
 
   // Generate common types once (stateless check)
@@ -129,7 +139,8 @@ export async function generateTypeScriptChannelsForOpenAPI(
 function processOpenAPIOperations(
   openapiDocument: OpenAPIDocument,
   payloads: TypeScriptPayloadRenderType,
-  parameters: TypeScriptParameterRenderType
+  parameters: TypeScriptParameterRenderType,
+  oauth2Enabled: boolean
 ): ReturnType<typeof renderHttpFetchClient>[] {
   const renders: ReturnType<typeof renderHttpFetchClient>[] = [];
 
@@ -144,7 +155,8 @@ function processOpenAPIOperations(
         method,
         path,
         payloads,
-        parameters
+        parameters,
+        oauth2Enabled
       );
       if (render) {
         renders.push(render);
@@ -163,7 +175,8 @@ function processOperation(
   method: HttpMethod,
   path: string,
   payloads: TypeScriptPayloadRenderType,
-  parameters: TypeScriptParameterRenderType
+  parameters: TypeScriptParameterRenderType,
+  oauth2Enabled: boolean
 ): ReturnType<typeof renderHttpFetchClient> | undefined {
   // eslint-disable-next-line security/detect-object-injection
   const operation = (pathItem as Record<string, unknown>)[method] as
@@ -250,7 +263,8 @@ function processOperation(
       | undefined,
     includesStatusCodes: replyIncludesStatusCodes,
     description,
-    deprecated
+    deprecated,
+    oauth2Enabled
   });
 }
 

--- a/src/codegen/generators/typescript/channels/protocols/http/client.ts
+++ b/src/codegen/generators/typescript/channels/protocols/http/client.ts
@@ -23,7 +23,8 @@ export function renderHttpFetchClient({
   functionName = `${method.toLowerCase()}${subName}`,
   includesStatusCodes = false,
   description,
-  deprecated
+  deprecated,
+  oauth2Enabled = true
 }: RenderHttpParameters): HttpRenderType {
   const messageType = requestMessageModule
     ? `${requestMessageModule}.${requestMessageType}`
@@ -66,7 +67,8 @@ export function renderHttpFetchClient({
     method,
     servers,
     includesStatusCodes,
-    jsDoc
+    jsDoc,
+    oauth2Enabled
   });
 
   const code = `${contextInterface}
@@ -134,6 +136,7 @@ function generateFunctionImplementation(params: {
   servers: string[];
   includesStatusCodes: boolean;
   jsDoc: string;
+  oauth2Enabled: boolean;
 }): string {
   const {
     functionName,
@@ -147,7 +150,8 @@ function generateFunctionImplementation(params: {
     method,
     servers,
     includesStatusCodes,
-    jsDoc
+    jsDoc,
+    oauth2Enabled
   } = params;
 
   const defaultServer = servers[0] ?? "'localhost:3000'";
@@ -183,6 +187,42 @@ function generateFunctionImplementation(params: {
   // Generate default context for optional context parameter
   const contextDefault = !hasBody && !hasParameters ? ' = {}' : '';
 
+  // OAuth2 request handling is only emitted when the API actually defines an
+  // OAuth2 scheme; otherwise these branches reference fields/functions that the
+  // narrowed AuthConfig union no longer carries and would fail to type-check.
+  const oauth2ValidateBlock = oauth2Enabled
+    ? `  // Validate OAuth2 config if present
+  if (config.auth?.type === 'oauth2' && AUTH_FEATURES.oauth2) {
+    validateOAuth2Config(config.auth);
+  }
+
+`
+    : '';
+
+  const oauth2TokenBlock = oauth2Enabled
+    ? `
+    // Handle OAuth2 token flows that require getting a token first
+    if (config.auth?.type === 'oauth2' && !config.auth.accessToken && AUTH_FEATURES.oauth2) {
+      const tokenFlowResponse = await handleOAuth2TokenFlow(config.auth, requestParams, makeRequest, config.retry);
+      if (tokenFlowResponse) {
+        response = tokenFlowResponse;
+      }
+    }
+
+    // Handle 401 with token refresh
+    if (response.status === 401 && config.auth?.type === 'oauth2' && AUTH_FEATURES.oauth2) {
+      try {
+        const refreshResponse = await handleTokenRefresh(config.auth, requestParams, makeRequest, config.retry);
+        if (refreshResponse) {
+          response = refreshResponse;
+        }
+      } catch {
+        throw new Error('Unauthorized');
+      }
+    }
+`
+    : '';
+
   return `${jsDoc}
 async function ${functionName}(context: ${contextInterfaceName}${contextDefault}): Promise<HttpClientResponse<${replyType}>> {
   // Apply defaults
@@ -192,12 +232,7 @@ async function ${functionName}(context: ${contextInterfaceName}${contextDefault}
     ...context,
   };
 
-  // Validate OAuth2 config if present
-  if (config.auth?.type === 'oauth2' && AUTH_FEATURES.oauth2) {
-    validateOAuth2Config(config.auth);
-  }
-
-  // Build headers
+${oauth2ValidateBlock}  // Build headers
   ${headersInit}
 
   // Build URL
@@ -241,27 +276,7 @@ async function ${functionName}(context: ${contextInterfaceName}${contextDefault}
     if (config.hooks?.afterResponse) {
       response = await config.hooks.afterResponse(response, requestParams);
     }
-
-    // Handle OAuth2 token flows that require getting a token first
-    if (config.auth?.type === 'oauth2' && !config.auth.accessToken && AUTH_FEATURES.oauth2) {
-      const tokenFlowResponse = await handleOAuth2TokenFlow(config.auth, requestParams, makeRequest, config.retry);
-      if (tokenFlowResponse) {
-        response = tokenFlowResponse;
-      }
-    }
-
-    // Handle 401 with token refresh
-    if (response.status === 401 && config.auth?.type === 'oauth2' && AUTH_FEATURES.oauth2) {
-      try {
-        const refreshResponse = await handleTokenRefresh(config.auth, requestParams, makeRequest, config.retry);
-        if (refreshResponse) {
-          response = refreshResponse;
-        }
-      } catch {
-        throw new Error('Unauthorized');
-      }
-    }
-
+${oauth2TokenBlock}
     // Handle error responses
     if (!response.ok) {
       handleHttpError(response.status, response.statusText);

--- a/src/codegen/generators/typescript/channels/protocols/http/common-types.ts
+++ b/src/codegen/generators/typescript/channels/protocols/http/common-types.ts
@@ -7,8 +7,8 @@ import {
   analyzeSecuritySchemes,
   escapeStringForCodeGen,
   getApiKeyDefaults,
+  renderApplyAuthCases,
   renderOAuth2Helpers,
-  renderOAuth2Stubs,
   renderSecurityTypes
 } from './security';
 
@@ -25,6 +25,35 @@ export function renderHttpCommonTypes(
 ): string {
   const requirements = analyzeSecuritySchemes(securitySchemes);
   const securityTypes = renderSecurityTypes(securitySchemes, requirements);
+  const applyAuthCases = renderApplyAuthCases(requirements);
+
+  // Only emit the AUTH_FEATURES flag when OAuth2 code is generated, and the
+  // API_KEY_DEFAULTS const when an apiKey case is generated - otherwise they
+  // become unused declarations in the output.
+  const authFeaturesBlock = requirements.oauth2
+    ? `
+/**
+ * Feature flags indicating which auth types are available.
+ * Used internally to conditionally call auth-specific helpers.
+ */
+const AUTH_FEATURES = {
+  oauth2: ${requirements.oauth2}
+} as const;
+`
+    : '';
+
+  const apiKeyDefaultsBlock = requirements.apiKey
+    ? `
+/**
+ * Default values for API key authentication derived from the spec.
+ * These match the defaults documented in the ApiKeyAuth interface.
+ */
+const API_KEY_DEFAULTS = {
+  name: '${escapeStringForCodeGen(getApiKeyDefaults(requirements.apiKeySchemes).name)}',
+  in: '${escapeStringForCodeGen(getApiKeyDefaults(requirements.apiKeySchemes).in)}' as 'header' | 'query' | 'cookie'
+} as const;
+`
+    : '';
 
   return `// ============================================================================
 // Common Types - Shared across all HTTP client functions
@@ -108,24 +137,7 @@ export interface TokenResponse {
 }
 
 ${securityTypes}
-
-/**
- * Feature flags indicating which auth types are available.
- * Used internally to conditionally call auth-specific helpers.
- */
-const AUTH_FEATURES = {
-  oauth2: ${requirements.oauth2}
-} as const;
-
-/**
- * Default values for API key authentication derived from the spec.
- * These match the defaults documented in the ApiKeyAuth interface.
- */
-const API_KEY_DEFAULTS = {
-  name: '${escapeStringForCodeGen(getApiKeyDefaults(requirements.apiKeySchemes).name)}',
-  in: '${escapeStringForCodeGen(getApiKeyDefaults(requirements.apiKeySchemes).in)}' as 'header' | 'query' | 'cookie'
-} as const;
-
+${authFeaturesBlock}${apiKeyDefaultsBlock}
 // ============================================================================
 // Pagination Types
 // ============================================================================
@@ -307,39 +319,7 @@ function applyAuth(
   if (!auth) return { headers, url };
 
   switch (auth.type) {
-    case 'bearer':
-      headers['Authorization'] = \`Bearer \${auth.token}\`;
-      break;
-
-    case 'basic': {
-      const credentials = Buffer.from(\`\${auth.username}:\${auth.password}\`).toString('base64');
-      headers['Authorization'] = \`Basic \${credentials}\`;
-      break;
-    }
-
-    case 'apiKey': {
-      const keyName = auth.name ?? API_KEY_DEFAULTS.name;
-      const keyIn = auth.in ?? API_KEY_DEFAULTS.in;
-
-      if (keyIn === 'header') {
-        headers[keyName] = auth.key;
-      } else if (keyIn === 'query') {
-        const separator = url.includes('?') ? '&' : '?';
-        url = \`\${url}\${separator}\${keyName}=\${encodeURIComponent(auth.key)}\`;
-      } else if (keyIn === 'cookie') {
-        headers['Cookie'] = \`\${keyName}=\${auth.key}\`;
-      }
-      break;
-    }
-
-    case 'oauth2': {
-      // If we have an access token, use it directly
-      // Token flows (client_credentials, password) are handled separately
-      if (auth.accessToken) {
-        headers['Authorization'] = \`Bearer \${auth.accessToken}\`;
-      }
-      break;
-    }
+${applyAuthCases}
   }
 
   return { headers, url };
@@ -805,7 +785,7 @@ function applyTypedHeaders(
 
   return headers;
 }
-${requirements.oauth2 ? renderOAuth2Helpers() : renderOAuth2Stubs()}
+${requirements.oauth2 ? renderOAuth2Helpers() : ''}
 // ============================================================================
 // Generated HTTP Client Functions
 // ============================================================================`;

--- a/src/codegen/generators/typescript/channels/protocols/http/index.ts
+++ b/src/codegen/generators/typescript/channels/protocols/http/index.ts
@@ -30,7 +30,6 @@ export {
   escapeStringForCodeGen,
   getApiKeyDefaults,
   renderOAuth2Helpers,
-  renderOAuth2Stubs,
   renderSecurityTypes,
   type AuthTypeRequirements
 } from './security';

--- a/src/codegen/generators/typescript/channels/protocols/http/security.ts
+++ b/src/codegen/generators/typescript/channels/protocols/http/security.ts
@@ -395,28 +395,62 @@ ${bearerSection}${basicSection}${apiKeySection}${oauth2Section}${renderAuthConfi
 }
 
 /**
- * Generate OAuth2 stub functions when OAuth2 is not available.
- * These stubs ensure TypeScript compilation succeeds when generated code
- * references OAuth2 functions, but the runtime guards prevent them from being called.
+ * Renders the `switch (auth.type)` case blocks for the generated `applyAuth`
+ * helper, emitting only the branches whose auth interfaces were generated.
+ *
+ * A case for an auth type absent from the (possibly narrowed) AuthConfig union
+ * would not type-check: the discriminant comparison has no overlap and the
+ * type-specific fields (`token`, `username`, `key`, `accessToken`, ...) don't
+ * exist on the union members that remain.
  */
-export function renderOAuth2Stubs(): string {
-  return `
-// OAuth2 helpers not needed for this API - provide type-safe stubs
-// These are never called due to AUTH_FEATURES.oauth2 runtime guards
-type OAuth2Auth = never;
-function validateOAuth2Config(_auth: OAuth2Auth): void {}
-async function handleOAuth2TokenFlow(
-  _auth: OAuth2Auth,
-  _originalParams: HttpRequestParams,
-  _makeRequest: (params: HttpRequestParams) => Promise<HttpResponse>,
-  _retryConfig?: RetryConfig
-): Promise<HttpResponse | null> { return null; }
-async function handleTokenRefresh(
-  _auth: OAuth2Auth,
-  _originalParams: HttpRequestParams,
-  _makeRequest: (params: HttpRequestParams) => Promise<HttpResponse>,
-  _retryConfig?: RetryConfig
-): Promise<HttpResponse | null> { return null; }`;
+export function renderApplyAuthCases(
+  requirements: AuthTypeRequirements
+): string {
+  const cases: string[] = [];
+
+  if (requirements.bearer) {
+    cases.push(`    case 'bearer':
+      headers['Authorization'] = \`Bearer \${auth.token}\`;
+      break;`);
+  }
+
+  if (requirements.basic) {
+    cases.push(`    case 'basic': {
+      const credentials = Buffer.from(\`\${auth.username}:\${auth.password}\`).toString('base64');
+      headers['Authorization'] = \`Basic \${credentials}\`;
+      break;
+    }`);
+  }
+
+  if (requirements.apiKey) {
+    cases.push(`    case 'apiKey': {
+      const keyName = auth.name ?? API_KEY_DEFAULTS.name;
+      const keyIn = auth.in ?? API_KEY_DEFAULTS.in;
+
+      if (keyIn === 'header') {
+        headers[keyName] = auth.key;
+      } else if (keyIn === 'query') {
+        const separator = url.includes('?') ? '&' : '?';
+        url = \`\${url}\${separator}\${keyName}=\${encodeURIComponent(auth.key)}\`;
+      } else if (keyIn === 'cookie') {
+        headers['Cookie'] = \`\${keyName}=\${auth.key}\`;
+      }
+      break;
+    }`);
+  }
+
+  if (requirements.oauth2) {
+    cases.push(`    case 'oauth2': {
+      // If we have an access token, use it directly
+      // Token flows (client_credentials, password) are handled separately
+      if (auth.accessToken) {
+        headers['Authorization'] = \`Bearer \${auth.accessToken}\`;
+      }
+      break;
+    }`);
+  }
+
+  return cases.join('\n\n');
 }
 
 /**

--- a/src/codegen/generators/typescript/channels/types.ts
+++ b/src/codegen/generators/typescript/channels/types.ts
@@ -280,6 +280,13 @@ export interface RenderHttpParameters {
   description?: string;
   /** Whether the operation is marked as deprecated in the API specification */
   deprecated?: boolean;
+  /**
+   * Whether OAuth2 auth is available for this API. When false, OAuth2-specific
+   * request handling is omitted so the generated function type-checks against an
+   * AuthConfig union that was narrowed to exclude OAuth2. Defaults to true to keep
+   * the AsyncAPI path (which generates all auth types) unchanged.
+   */
+  oauth2Enabled?: boolean;
 }
 
 export type SupportedProtocols =

--- a/test/codegen/generators/typescript/__snapshots__/channels.spec.ts.snap
+++ b/test/codegen/generators/typescript/__snapshots__/channels.spec.ts.snap
@@ -348,16 +348,6 @@ function applyAuth(
   if (!auth) return { headers, url };
 
   switch (auth.type) {
-    case 'bearer':
-      headers['Authorization'] = \`Bearer \${auth.token}\`;
-      break;
-
-    case 'basic': {
-      const credentials = Buffer.from(\`\${auth.username}:\${auth.password}\`).toString('base64');
-      headers['Authorization'] = \`Basic \${credentials}\`;
-      break;
-    }
-
     case 'apiKey': {
       const keyName = auth.name ?? API_KEY_DEFAULTS.name;
       const keyIn = auth.in ?? API_KEY_DEFAULTS.in;

--- a/test/codegen/generators/typescript/channels/protocols/http/fetch-security.spec.ts
+++ b/test/codegen/generators/typescript/channels/protocols/http/fetch-security.spec.ts
@@ -1,5 +1,6 @@
 import {
   renderHttpCommonTypes,
+  renderHttpFetchClient,
   SecuritySchemeOptions
 } from '../../../../../../../src/codegen/generators/typescript/channels/protocols/http';
 
@@ -123,7 +124,9 @@ describe('HTTP Fetch Generator - Security Types', () => {
       expect(result).not.toContain('export interface OAuth2Auth');
 
       // AuthConfig should be a union of the defined types
-      expect(result).toMatch(/export type AuthConfig = (?:ApiKeyAuth \| BearerAuth|BearerAuth \| ApiKeyAuth)/);
+      expect(result).toMatch(
+        /export type AuthConfig = (?:ApiKeyAuth \| BearerAuth|BearerAuth \| ApiKeyAuth)/
+      );
     });
 
     it('should generate all auth types when no security schemes defined (backward compatibility)', () => {
@@ -189,7 +192,8 @@ describe('HTTP Fetch Generator - Security Types', () => {
         {
           name: 'oidc',
           type: 'openIdConnect',
-          openIdConnectUrl: 'https://example.com/.well-known/openid-configuration'
+          openIdConnectUrl:
+            'https://example.com/.well-known/openid-configuration'
         }
       ];
 
@@ -197,7 +201,42 @@ describe('HTTP Fetch Generator - Security Types', () => {
 
       // OpenID Connect should be treated similar to OAuth2
       expect(result).toContain('export interface OAuth2Auth');
-      expect(result).toContain('https://example.com/.well-known/openid-configuration');
+      expect(result).toContain(
+        'https://example.com/.well-known/openid-configuration'
+      );
+    });
+
+    it('should only emit auth branches for the schemes actually defined', () => {
+      // A bearer-only spec narrows AuthConfig to BearerAuth. The generated
+      // helpers must not reference the other auth types, otherwise the output
+      // fails to type-check (fields/discriminants that no longer exist).
+      const result = renderHttpCommonTypes([
+        {name: 'bearerAuth', type: 'http', httpScheme: 'bearer'}
+      ]);
+
+      expect(result).toContain("case 'bearer':");
+      expect(result).not.toContain("case 'basic'");
+      expect(result).not.toContain("case 'apiKey'");
+      expect(result).not.toContain("case 'oauth2'");
+
+      // OAuth2 helpers and the feature flag are OAuth2-only - omit them entirely
+      expect(result).not.toContain('handleOAuth2TokenFlow');
+      expect(result).not.toContain('validateOAuth2Config');
+      expect(result).not.toContain('AUTH_FEATURES');
+
+      // API key defaults are only referenced by the apiKey branch
+      expect(result).not.toContain('API_KEY_DEFAULTS');
+    });
+
+    it('should emit every auth branch in backward-compatible mode (no schemes)', () => {
+      const result = renderHttpCommonTypes();
+
+      expect(result).toContain("case 'bearer':");
+      expect(result).toContain("case 'basic'");
+      expect(result).toContain("case 'apiKey'");
+      expect(result).toContain("case 'oauth2'");
+      expect(result).toContain('AUTH_FEATURES');
+      expect(result).toContain('API_KEY_DEFAULTS');
     });
 
     it('should deduplicate auth types when same type defined multiple times', () => {
@@ -219,12 +258,47 @@ describe('HTTP Fetch Generator - Security Types', () => {
       const result = renderHttpCommonTypes(securitySchemes);
 
       // Should only have one ApiKeyAuth interface
-      const apiKeyInterfaceMatches = result.match(/export interface ApiKeyAuth/g);
+      const apiKeyInterfaceMatches = result.match(
+        /export interface ApiKeyAuth/g
+      );
       expect(apiKeyInterfaceMatches).toHaveLength(1);
 
       // AuthConfig should still only have ApiKeyAuth once
       expect(result).toContain('export type AuthConfig = ApiKeyAuth');
       expect(result).not.toMatch(/ApiKeyAuth \| ApiKeyAuth/);
+    });
+  });
+
+  describe('renderHttpFetchClient OAuth2 request handling', () => {
+    const baseParams = {
+      requestTopic: '/pet',
+      requestMessageModule: undefined,
+      requestMessageType: undefined,
+      replyMessageType: 'Pet',
+      replyMessageModule: undefined,
+      channelParameters: undefined,
+      method: 'GET' as const
+    };
+
+    it('omits OAuth2 request handling when oauth2Enabled is false', () => {
+      const {code} = renderHttpFetchClient({
+        ...baseParams,
+        oauth2Enabled: false
+      });
+
+      expect(code).not.toContain("config.auth?.type === 'oauth2'");
+      expect(code).not.toContain('validateOAuth2Config');
+      expect(code).not.toContain('handleOAuth2TokenFlow');
+      expect(code).not.toContain('handleTokenRefresh');
+    });
+
+    it('keeps OAuth2 request handling by default (AsyncAPI parity)', () => {
+      const {code} = renderHttpFetchClient(baseParams);
+
+      expect(code).toContain("config.auth?.type === 'oauth2'");
+      expect(code).toContain('validateOAuth2Config');
+      expect(code).toContain('handleOAuth2TokenFlow');
+      expect(code).toContain('handleTokenRefresh');
     });
   });
 });


### PR DESCRIPTION
## Why

When an OpenAPI document declares only a subset of security schemes, the HTTP client generator correctly narrows the `AuthConfig` union to just those types — but it still emitted the request-handling code for **every** auth type. For a spec with, say, a single `http`/`bearer` scheme, the generated client failed to type-check:

- `applyAuth` `switch`ed over `basic` / `apiKey` / `oauth2` cases whose fields (`username`, `key`, `accessToken`, …) and discriminants no longer exist on the narrowed union (`TS2678`, `TS2339`).
- Every operation compared `config.auth?.type === 'oauth2'` (`TS2367` — no overlap) and passed `config.auth` to OAuth2-only helpers typed `never` (`TS2345`).

This was never caught because the runtime test suite compiles generated code with **swc**, which strips types without type-checking. Real `tsc` (e.g. on `npm publish` of a generated client) surfaces it.

## What

Generate auth branches **conditionally**, matching the narrowed types:

- `applyAuth` emits only the `case` blocks for the schemes actually present (new `renderApplyAuthCases`).
- `AUTH_FEATURES` / `API_KEY_DEFAULTS` are emitted only when `oauth2` / `apiKey` are present (otherwise they'd be unused).
- OAuth2 helpers and the per-operation OAuth2 token/refresh handling are gated behind a new `oauth2Enabled` flag threaded from the OpenAPI channel generator.
- Dropped the now-unused `renderOAuth2Stubs`.

The **AsyncAPI HTTP path is unchanged**: `oauth2Enabled` defaults to `true` and that path still generates the full auth union, so its output is byte-identical.

## Tests

- New `fetch-security.spec.ts` cases asserting a bearer-only spec emits only the `bearer` branch (no `basic`/`apiKey`/`oauth2` handling, no `AUTH_FEATURES`/`API_KEY_DEFAULTS`), and full backward-compatible mode still emits all branches.
- New cases asserting `renderHttpFetchClient` omits vs. keeps OAuth2 request handling based on `oauth2Enabled`.
- Updated the openapi `channels.spec` snapshot (removes the dead `bearer`/`basic` cases that never type-checked).
- Verified end-to-end by generating a real bearer-only OpenAPI 3.1 spec: **0 auth type errors** (was ~30+).

🤖 Generated with [Claude Code](https://claude.com/claude-code)