### PR TITLE
fix(openapi): unmarshal HTTP responses from raw JSON text

### DIFF
--- a/src/codegen/generators/typescript/channels/protocols/http/client.ts
+++ b/src/codegen/generators/typescript/channels/protocols/http/client.ts
@@ -169,15 +169,20 @@ function generateFunctionImplementation(params: {
     ? `const body = context.payload?.marshal();`
     : `const body = undefined;`;
 
-  // Generate response parsing
-  // Use unmarshalByStatusCode if the payload is a union type with status code support
+  // Generate response parsing.
+  // Use unmarshalByStatusCode if the payload is a union type with status code support.
+  // unmarshal receives the raw JSON text (JSON.stringify(rawData)) rather than the
+  // parsed object: object/array models accept either, but primitive-typed payloads
+  // (e.g. `type X = string`) generate `unmarshal(json: string)` which JSON.parses its
+  // argument, so passing the already-parsed value would both fail to type-check and
+  // throw at runtime.
   let responseParseCode: string;
   if (replyMessageModule) {
     responseParseCode = includesStatusCodes
-      ? `const responseData = ${replyMessageModule}.unmarshalByStatusCode(rawData, response.status);`
-      : `const responseData = ${replyMessageModule}.unmarshal(rawData);`;
+      ? `const responseData = ${replyMessageModule}.unmarshalByStatusCode(JSON.stringify(rawData), response.status);`
+      : `const responseData = ${replyMessageModule}.unmarshal(JSON.stringify(rawData));`;
   } else {
-    responseParseCode = `const responseData = ${replyMessageType}.unmarshal(rawData);`;
+    responseParseCode = `const responseData = ${replyMessageType}.unmarshal(JSON.stringify(rawData));`;
   }
 
   // Generate default context for optional context parameter

--- a/test/codegen/generators/typescript/__snapshots__/channels.spec.ts.snap
+++ b/test/codegen/generators/typescript/__snapshots__/channels.spec.ts.snap
@@ -1093,7 +1093,7 @@ async function addPet(context: AddPetContext): Promise<HttpClientResponse<Pet>> 
 
     // Parse response
     const rawData = await response.json();
-    const responseData = Pet.unmarshal(rawData);
+    const responseData = Pet.unmarshal(JSON.stringify(rawData));
 
     // Extract response metadata
     const responseHeaders = extractHeaders(response);
@@ -1216,7 +1216,7 @@ async function updatePet(context: UpdatePetContext): Promise<HttpClientResponse<
 
     // Parse response
     const rawData = await response.json();
-    const responseData = Pet.unmarshal(rawData);
+    const responseData = Pet.unmarshal(JSON.stringify(rawData));
 
     // Extract response metadata
     const responseHeaders = extractHeaders(response);
@@ -1339,7 +1339,7 @@ async function findPetsByStatusAndCategory(context: FindPetsByStatusAndCategoryC
 
     // Parse response
     const rawData = await response.json();
-    const responseData = FindPetsByStatusAndCategoryResponseModule.unmarshal(rawData);
+    const responseData = FindPetsByStatusAndCategoryResponseModule.unmarshal(JSON.stringify(rawData));
 
     // Extract response metadata
     const responseHeaders = extractHeaders(response);
@@ -3028,7 +3028,7 @@ async function getPingRequest(context: GetPingRequestContext = {}): Promise<Http
 
     // Parse response
     const rawData = await response.json();
-    const responseData = TestPayloadModelModule.unmarshal(rawData);
+    const responseData = TestPayloadModelModule.unmarshal(JSON.stringify(rawData));
 
     // Extract response metadata
     const responseHeaders = extractHeaders(response);

--- a/test/codegen/generators/typescript/channels.spec.ts
+++ b/test/codegen/generators/typescript/channels.spec.ts
@@ -622,6 +622,13 @@ describe('channels', () => {
         expect(generatedChannels.files.length).toBeGreaterThan(0);
         expect(generatedChannels.result).toMatchSnapshot('openapi-http_client-index');
         expect(generatedChannels.protocolFiles['http_client']).toMatchSnapshot('openapi-http_client-protocol-code');
+
+        // Responses are unmarshalled from the raw JSON text, not the parsed
+        // object, so primitive-typed payloads whose unmarshal JSON.parses its
+        // argument keep working. See fix/openapi-http-client-primitive-response.
+        const httpProtocolCode = generatedChannels.protocolFiles['http_client'];
+        expect(httpProtocolCode).toContain('unmarshal(JSON.stringify(rawData))');
+        expect(httpProtocolCode).not.toMatch(/unmarshal\(rawData\)/);
       });
 
       it('should skip generation when http_client is not in protocols', async () => {

--- a/test/runtime/openapi-primitive.json
+++ b/test/runtime/openapi-primitive.json
@@ -1,0 +1,42 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Primitive Response API",
+    "version": "1.0.0",
+    "description": "Minimal spec whose operations return primitive (non-object) payloads, used to prove the HTTP client unmarshals string/number bodies correctly."
+  },
+  "paths": {
+    "/echo": {
+      "get": {
+        "operationId": "getEcho",
+        "summary": "Return a plain string body",
+        "responses": {
+          "200": {
+            "description": "A plain string",
+            "content": {
+              "application/json": {
+                "schema": { "type": "string" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/count": {
+      "get": {
+        "operationId": "getCount",
+        "summary": "Return a plain number body",
+        "responses": {
+          "200": {
+            "description": "A plain number",
+            "content": {
+              "application/json": {
+                "schema": { "type": "number" }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/runtime/typescript/codegen-openapi-primitive.mjs
+++ b/test/runtime/typescript/codegen-openapi-primitive.mjs
@@ -1,0 +1,30 @@
+/** @type {import("../../../dist").TheCodegenConfiguration} **/
+export default {
+	inputType: 'openapi',
+	inputPath: '../openapi-primitive.json',
+	language: 'typescript',
+	generators: [
+		{
+			preset: 'payloads',
+			outputPath: './src/openapi-primitive/payloads',
+			serializationType: 'json',
+		},
+		{
+			preset: 'parameters',
+			outputPath: './src/openapi-primitive/parameters',
+		},
+		{
+			preset: 'headers',
+			outputPath: './src/openapi-primitive/headers',
+		},
+		{
+			preset: 'types',
+			outputPath: './src/openapi-primitive',
+		},
+		{
+			preset: 'channels',
+			outputPath: './src/openapi-primitive/channels',
+			protocols: ['http_client']
+		}
+	]
+};

--- a/test/runtime/typescript/package.json
+++ b/test/runtime/typescript/package.json
@@ -12,10 +12,11 @@
     "test:websocket": "jest -- ./test/channels/regular/websocket.spec.ts",
     "test:http": "jest -- ./test/channels/request_reply/http_client/",
     "test:payload-types": "jest -- ./test/payload-types/",
-    "generate": "npm run generate:regular && npm run generate:request:reply && npm run generate:openapi && npm run generate:payload-types",
+    "generate": "npm run generate:regular && npm run generate:request:reply && npm run generate:openapi && npm run generate:openapi-primitive && npm run generate:payload-types",
     "generate:request:reply": "cross-env CODEGEN_TELEMETRY_DISABLED=1 node ../../../bin/run.mjs generate ./codegen-request-reply.mjs",
     "generate:regular": "cross-env CODEGEN_TELEMETRY_DISABLED=1 node ../../../bin/run.mjs generate ./codegen-regular.mjs",
     "generate:openapi": "cross-env CODEGEN_TELEMETRY_DISABLED=1 node ../../../bin/run.mjs generate ./codegen-openapi.mjs",
+    "generate:openapi-primitive": "cross-env CODEGEN_TELEMETRY_DISABLED=1 node ../../../bin/run.mjs generate ./codegen-openapi-primitive.mjs",
     "generate:payload-types": "cross-env CODEGEN_TELEMETRY_DISABLED=1 node ../../../bin/run.mjs generate ./codegen-payload-types.mjs",
     "debug:generate": "node --inspect-brk ../../../bin/run.mjs generate"
   },

--- a/test/runtime/typescript/src/openapi-primitive/Types.ts
+++ b/test/runtime/typescript/src/openapi-primitive/Types.ts
@@ -1,0 +1,26 @@
+export type Paths = '/echo' | '/count';
+export type OperationIds = 'getEcho' | 'getCount';
+export function ToPath(operationId: OperationIds): Paths {
+  switch (operationId) {
+    case 'getEcho':
+    return '/echo';
+  case 'getCount':
+    return '/count';
+    default:
+      throw new Error('Unknown operation ID: ' + operationId);
+  }
+}
+export function ToOperationIds(path: Paths): OperationIds[] {
+  switch (path) {
+    case '/echo':
+    return ['getEcho'];
+  case '/count':
+    return ['getCount'];
+    default:
+      throw new Error('Unknown path: ' + path);
+  }
+}
+export const PathsMap: Record<OperationIds, Paths> = {
+  'getEcho': '/echo',
+  'getCount': '/count'
+};

--- a/test/runtime/typescript/src/openapi-primitive/channels/http_client.ts
+++ b/test/runtime/typescript/src/openapi-primitive/channels/http_client.ts
@@ -1,14 +1,5 @@
-import {APet} from './../payloads/APet';
-import * as FindPetsByStatusAndCategoryResponse_200Module from './../payloads/FindPetsByStatusAndCategoryResponse_200';
-import {PetCategory} from './../payloads/PetCategory';
-import {PetTag} from './../payloads/PetTag';
-import {Status} from './../payloads/Status';
-import {ItemStatus} from './../payloads/ItemStatus';
-import {PetOrder} from './../payloads/PetOrder';
-import {AUser} from './../payloads/AUser';
-import {AnUploadedResponse} from './../payloads/AnUploadedResponse';
-import {FindPetsByStatusAndCategoryParameters} from './../parameters/FindPetsByStatusAndCategoryParameters';
-import {FindPetsByStatusAndCategoryHeaders} from './../headers/FindPetsByStatusAndCategoryHeaders';
+import * as GetEchoResponse_200Module from './../payloads/GetEchoResponse_200';
+import * as GetCountResponse_200Module from './../payloads/GetCountResponse_200';
 import { URLSearchParams, URL } from 'url';
 import * as NodeFetch from 'node-fetch';
 
@@ -98,12 +89,29 @@ export interface TokenResponse {
 // ============================================================================
 
 /**
+ * Bearer token authentication configuration
+ */
+export interface BearerAuth {
+  type: 'bearer';
+  token: string;
+}
+
+/**
+ * Basic authentication configuration (username/password)
+ */
+export interface BasicAuth {
+  type: 'basic';
+  username: string;
+  password: string;
+}
+
+/**
  * API key authentication configuration
  */
 export interface ApiKeyAuth {
   type: 'apiKey';
   key: string;
-  name?: string;        // Name of the API key parameter (default: 'api_key')
+  name?: string;        // Name of the API key parameter (default: 'X-API-Key')
   in?: 'header' | 'query'; // Where to place the API key (default: 'header')
 }
 
@@ -117,7 +125,6 @@ export interface ApiKeyAuth {
  *
  * For browser-based flows (implicit, authorization_code), obtain the token
  * separately and pass it as accessToken.
- * Authorization URL: 'http://petstore.swagger.io/api/oauth/dialog'
  */
 export interface OAuth2Auth {
   type: 'oauth2';
@@ -131,7 +138,7 @@ export interface OAuth2Auth {
   clientId?: string;
   /** Client secret (optional, depends on OAuth provider) */
   clientSecret?: string;
-  /** Requested scopes Available: write:pets, read:pets */
+  /** Requested scopes */
   scopes?: string[];
   /** Server-side flow type */
   flow?: 'password' | 'client_credentials';
@@ -146,7 +153,7 @@ export interface OAuth2Auth {
 /**
  * Union type for all authentication methods - provides autocomplete support
  */
-export type AuthConfig = ApiKeyAuth | OAuth2Auth;
+export type AuthConfig = BearerAuth | BasicAuth | ApiKeyAuth | OAuth2Auth;
 
 /**
  * Feature flags indicating which auth types are available.
@@ -161,7 +168,7 @@ const AUTH_FEATURES = {
  * These match the defaults documented in the ApiKeyAuth interface.
  */
 const API_KEY_DEFAULTS = {
-  name: 'api_key',
+  name: 'X-API-Key',
   in: 'header' as 'header' | 'query' | 'cookie'
 } as const;
 
@@ -996,18 +1003,17 @@ async function handleTokenRefresh(
 // Generated HTTP Client Functions
 // ============================================================================
 
-export interface AddPetContext extends HttpClientContext {
-  payload: APet;
+export interface GetEchoContext extends HttpClientContext {
   requestHeaders?: { marshal: () => string };
 }
 
 /**
- * HTTP POST request to /pet
+ * Return a plain string body
  */
-async function addPet(context: AddPetContext): Promise<HttpClientResponse<APet>> {
+async function getEcho(context: GetEchoContext = {}): Promise<HttpClientResponse<GetEchoResponse_200Module.GetEchoResponse_200>> {
   // Apply defaults
   const config = {
-    path: '/pet',
+    path: '/echo',
     server: 'localhost:3000',
     ...context,
   };
@@ -1024,252 +1030,6 @@ async function addPet(context: AddPetContext): Promise<HttpClientResponse<APet>>
 
   // Build URL
   let url = `${config.server}${config.path}`;
-  url = applyQueryParams(config.queryParams, url);
-
-  // Apply pagination (can affect URL and/or headers)
-  const paginationResult = applyPagination(config.pagination, url, headers);
-  url = paginationResult.url;
-  headers = paginationResult.headers;
-
-  // Apply authentication
-  const authResult = applyAuth(config.auth, headers, url);
-  headers = authResult.headers;
-  url = authResult.url;
-
-  // Prepare body
-  const body = context.payload?.marshal();
-
-  // Determine request function
-  const makeRequest = config.hooks?.makeRequest ?? defaultMakeRequest;
-
-  // Build request params
-  let requestParams: HttpRequestParams = {
-    url,
-    method: 'POST',
-    headers,
-    body
-  };
-
-  // Apply beforeRequest hook
-  if (config.hooks?.beforeRequest) {
-    requestParams = await config.hooks.beforeRequest(requestParams);
-  }
-
-  try {
-    // Execute request with retry logic
-    let response = await executeWithRetry(requestParams, makeRequest, config.retry);
-
-    // Apply afterResponse hook
-    if (config.hooks?.afterResponse) {
-      response = await config.hooks.afterResponse(response, requestParams);
-    }
-
-    // Handle OAuth2 token flows that require getting a token first
-    if (config.auth?.type === 'oauth2' && !config.auth.accessToken && AUTH_FEATURES.oauth2) {
-      const tokenFlowResponse = await handleOAuth2TokenFlow(config.auth, requestParams, makeRequest, config.retry);
-      if (tokenFlowResponse) {
-        response = tokenFlowResponse;
-      }
-    }
-
-    // Handle 401 with token refresh
-    if (response.status === 401 && config.auth?.type === 'oauth2' && AUTH_FEATURES.oauth2) {
-      try {
-        const refreshResponse = await handleTokenRefresh(config.auth, requestParams, makeRequest, config.retry);
-        if (refreshResponse) {
-          response = refreshResponse;
-        }
-      } catch {
-        throw new Error('Unauthorized');
-      }
-    }
-
-    // Handle error responses
-    if (!response.ok) {
-      handleHttpError(response.status, response.statusText);
-    }
-
-    // Parse response
-    const rawData = await response.json();
-    const responseData = APet.unmarshal(JSON.stringify(rawData));
-
-    // Extract response metadata
-    const responseHeaders = extractHeaders(response);
-    const paginationInfo = extractPaginationInfo(responseHeaders, config.pagination);
-
-    // Build response wrapper with pagination helpers
-    const result: HttpClientResponse<APet> = {
-      data: responseData,
-      status: response.status,
-      statusText: response.statusText,
-      headers: responseHeaders,
-      rawData,
-      pagination: paginationInfo,
-      ...createPaginationHelpers(config, paginationInfo, addPet),
-    };
-
-    return result;
-
-  } catch (error) {
-    // Apply onError hook if present
-    if (config.hooks?.onError && error instanceof Error) {
-      throw await config.hooks.onError(error, requestParams);
-    }
-    throw error;
-  }
-}
-
-export interface UpdatePetContext extends HttpClientContext {
-  payload: APet;
-  requestHeaders?: { marshal: () => string };
-}
-
-/**
- * HTTP PUT request to /pet
- */
-async function updatePet(context: UpdatePetContext): Promise<HttpClientResponse<APet>> {
-  // Apply defaults
-  const config = {
-    path: '/pet',
-    server: 'localhost:3000',
-    ...context,
-  };
-
-  // Validate OAuth2 config if present
-  if (config.auth?.type === 'oauth2' && AUTH_FEATURES.oauth2) {
-    validateOAuth2Config(config.auth);
-  }
-
-  // Build headers
-  let headers = context.requestHeaders
-    ? applyTypedHeaders(context.requestHeaders, config.additionalHeaders)
-    : { 'Content-Type': 'application/json', ...config.additionalHeaders } as Record<string, string | string[]>;
-
-  // Build URL
-  let url = `${config.server}${config.path}`;
-  url = applyQueryParams(config.queryParams, url);
-
-  // Apply pagination (can affect URL and/or headers)
-  const paginationResult = applyPagination(config.pagination, url, headers);
-  url = paginationResult.url;
-  headers = paginationResult.headers;
-
-  // Apply authentication
-  const authResult = applyAuth(config.auth, headers, url);
-  headers = authResult.headers;
-  url = authResult.url;
-
-  // Prepare body
-  const body = context.payload?.marshal();
-
-  // Determine request function
-  const makeRequest = config.hooks?.makeRequest ?? defaultMakeRequest;
-
-  // Build request params
-  let requestParams: HttpRequestParams = {
-    url,
-    method: 'PUT',
-    headers,
-    body
-  };
-
-  // Apply beforeRequest hook
-  if (config.hooks?.beforeRequest) {
-    requestParams = await config.hooks.beforeRequest(requestParams);
-  }
-
-  try {
-    // Execute request with retry logic
-    let response = await executeWithRetry(requestParams, makeRequest, config.retry);
-
-    // Apply afterResponse hook
-    if (config.hooks?.afterResponse) {
-      response = await config.hooks.afterResponse(response, requestParams);
-    }
-
-    // Handle OAuth2 token flows that require getting a token first
-    if (config.auth?.type === 'oauth2' && !config.auth.accessToken && AUTH_FEATURES.oauth2) {
-      const tokenFlowResponse = await handleOAuth2TokenFlow(config.auth, requestParams, makeRequest, config.retry);
-      if (tokenFlowResponse) {
-        response = tokenFlowResponse;
-      }
-    }
-
-    // Handle 401 with token refresh
-    if (response.status === 401 && config.auth?.type === 'oauth2' && AUTH_FEATURES.oauth2) {
-      try {
-        const refreshResponse = await handleTokenRefresh(config.auth, requestParams, makeRequest, config.retry);
-        if (refreshResponse) {
-          response = refreshResponse;
-        }
-      } catch {
-        throw new Error('Unauthorized');
-      }
-    }
-
-    // Handle error responses
-    if (!response.ok) {
-      handleHttpError(response.status, response.statusText);
-    }
-
-    // Parse response
-    const rawData = await response.json();
-    const responseData = APet.unmarshal(JSON.stringify(rawData));
-
-    // Extract response metadata
-    const responseHeaders = extractHeaders(response);
-    const paginationInfo = extractPaginationInfo(responseHeaders, config.pagination);
-
-    // Build response wrapper with pagination helpers
-    const result: HttpClientResponse<APet> = {
-      data: responseData,
-      status: response.status,
-      statusText: response.statusText,
-      headers: responseHeaders,
-      rawData,
-      pagination: paginationInfo,
-      ...createPaginationHelpers(config, paginationInfo, updatePet),
-    };
-
-    return result;
-
-  } catch (error) {
-    // Apply onError hook if present
-    if (config.hooks?.onError && error instanceof Error) {
-      throw await config.hooks.onError(error, requestParams);
-    }
-    throw error;
-  }
-}
-
-export interface FindPetsByStatusAndCategoryContext extends HttpClientContext {
-  parameters: { getChannelWithParameters: (path: string) => string };
-  requestHeaders?: { marshal: () => string };
-}
-
-/**
- * Find pets by status and category with additional filtering options
- */
-async function findPetsByStatusAndCategory(context: FindPetsByStatusAndCategoryContext): Promise<HttpClientResponse<FindPetsByStatusAndCategoryResponse_200Module.FindPetsByStatusAndCategoryResponse_200>> {
-  // Apply defaults
-  const config = {
-    path: '/pet/findByStatus/{status}/{categoryId}',
-    server: 'localhost:3000',
-    ...context,
-  };
-
-  // Validate OAuth2 config if present
-  if (config.auth?.type === 'oauth2' && AUTH_FEATURES.oauth2) {
-    validateOAuth2Config(config.auth);
-  }
-
-  // Build headers
-  let headers = context.requestHeaders
-    ? applyTypedHeaders(context.requestHeaders, config.additionalHeaders)
-    : { 'Content-Type': 'application/json', ...config.additionalHeaders } as Record<string, string | string[]>;
-
-  // Build URL
-  let url = buildUrlWithParameters(config.server, '/pet/findByStatus/{status}/{categoryId}', context.parameters);
   url = applyQueryParams(config.queryParams, url);
 
   // Apply pagination (can affect URL and/or headers)
@@ -1337,21 +1097,21 @@ async function findPetsByStatusAndCategory(context: FindPetsByStatusAndCategoryC
 
     // Parse response
     const rawData = await response.json();
-    const responseData = FindPetsByStatusAndCategoryResponse_200Module.unmarshal(JSON.stringify(rawData));
+    const responseData = GetEchoResponse_200Module.unmarshal(JSON.stringify(rawData));
 
     // Extract response metadata
     const responseHeaders = extractHeaders(response);
     const paginationInfo = extractPaginationInfo(responseHeaders, config.pagination);
 
     // Build response wrapper with pagination helpers
-    const result: HttpClientResponse<FindPetsByStatusAndCategoryResponse_200Module.FindPetsByStatusAndCategoryResponse_200> = {
+    const result: HttpClientResponse<GetEchoResponse_200Module.GetEchoResponse_200> = {
       data: responseData,
       status: response.status,
       statusText: response.statusText,
       headers: responseHeaders,
       rawData,
       pagination: paginationInfo,
-      ...createPaginationHelpers(config, paginationInfo, findPetsByStatusAndCategory),
+      ...createPaginationHelpers(config, paginationInfo, getEcho),
     };
 
     return result;
@@ -1365,4 +1125,126 @@ async function findPetsByStatusAndCategory(context: FindPetsByStatusAndCategoryC
   }
 }
 
-export { addPet, updatePet, findPetsByStatusAndCategory };
+export interface GetCountContext extends HttpClientContext {
+  requestHeaders?: { marshal: () => string };
+}
+
+/**
+ * Return a plain number body
+ */
+async function getCount(context: GetCountContext = {}): Promise<HttpClientResponse<GetCountResponse_200Module.GetCountResponse_200>> {
+  // Apply defaults
+  const config = {
+    path: '/count',
+    server: 'localhost:3000',
+    ...context,
+  };
+
+  // Validate OAuth2 config if present
+  if (config.auth?.type === 'oauth2' && AUTH_FEATURES.oauth2) {
+    validateOAuth2Config(config.auth);
+  }
+
+  // Build headers
+  let headers = context.requestHeaders
+    ? applyTypedHeaders(context.requestHeaders, config.additionalHeaders)
+    : { 'Content-Type': 'application/json', ...config.additionalHeaders } as Record<string, string | string[]>;
+
+  // Build URL
+  let url = `${config.server}${config.path}`;
+  url = applyQueryParams(config.queryParams, url);
+
+  // Apply pagination (can affect URL and/or headers)
+  const paginationResult = applyPagination(config.pagination, url, headers);
+  url = paginationResult.url;
+  headers = paginationResult.headers;
+
+  // Apply authentication
+  const authResult = applyAuth(config.auth, headers, url);
+  headers = authResult.headers;
+  url = authResult.url;
+
+  // Prepare body
+  const body = undefined;
+
+  // Determine request function
+  const makeRequest = config.hooks?.makeRequest ?? defaultMakeRequest;
+
+  // Build request params
+  let requestParams: HttpRequestParams = {
+    url,
+    method: 'GET',
+    headers,
+    body
+  };
+
+  // Apply beforeRequest hook
+  if (config.hooks?.beforeRequest) {
+    requestParams = await config.hooks.beforeRequest(requestParams);
+  }
+
+  try {
+    // Execute request with retry logic
+    let response = await executeWithRetry(requestParams, makeRequest, config.retry);
+
+    // Apply afterResponse hook
+    if (config.hooks?.afterResponse) {
+      response = await config.hooks.afterResponse(response, requestParams);
+    }
+
+    // Handle OAuth2 token flows that require getting a token first
+    if (config.auth?.type === 'oauth2' && !config.auth.accessToken && AUTH_FEATURES.oauth2) {
+      const tokenFlowResponse = await handleOAuth2TokenFlow(config.auth, requestParams, makeRequest, config.retry);
+      if (tokenFlowResponse) {
+        response = tokenFlowResponse;
+      }
+    }
+
+    // Handle 401 with token refresh
+    if (response.status === 401 && config.auth?.type === 'oauth2' && AUTH_FEATURES.oauth2) {
+      try {
+        const refreshResponse = await handleTokenRefresh(config.auth, requestParams, makeRequest, config.retry);
+        if (refreshResponse) {
+          response = refreshResponse;
+        }
+      } catch {
+        throw new Error('Unauthorized');
+      }
+    }
+
+    // Handle error responses
+    if (!response.ok) {
+      handleHttpError(response.status, response.statusText);
+    }
+
+    // Parse response
+    const rawData = await response.json();
+    const responseData = GetCountResponse_200Module.unmarshal(JSON.stringify(rawData));
+
+    // Extract response metadata
+    const responseHeaders = extractHeaders(response);
+    const paginationInfo = extractPaginationInfo(responseHeaders, config.pagination);
+
+    // Build response wrapper with pagination helpers
+    const result: HttpClientResponse<GetCountResponse_200Module.GetCountResponse_200> = {
+      data: responseData,
+      status: response.status,
+      statusText: response.statusText,
+      headers: responseHeaders,
+      rawData,
+      pagination: paginationInfo,
+      ...createPaginationHelpers(config, paginationInfo, getCount),
+    };
+
+    return result;
+
+  } catch (error) {
+    // Apply onError hook if present
+    if (config.hooks?.onError && error instanceof Error) {
+      throw await config.hooks.onError(error, requestParams);
+    }
+    throw error;
+  }
+}
+
+export { getEcho, getCount };

--- a/test/runtime/typescript/src/openapi-primitive/channels/index.ts
+++ b/test/runtime/typescript/src/openapi-primitive/channels/index.ts
@@ -1,0 +1,3 @@
+import * as http_client from './http_client';
+
+export {http_client};

--- a/test/runtime/typescript/src/openapi-primitive/payloads/GetCountResponse_200.ts
+++ b/test/runtime/typescript/src/openapi-primitive/payloads/GetCountResponse_200.ts
@@ -1,0 +1,33 @@
+import {Ajv, Options as AjvOptions, ErrorObject, ValidateFunction} from 'ajv';
+import {default as addFormats} from 'ajv-formats';
+type GetCountResponse_200 = number;
+
+export function unmarshal(json: string): GetCountResponse_200 {
+  return JSON.parse(json) as GetCountResponse_200;
+}
+export function marshal(payload: GetCountResponse_200): string {
+  return JSON.stringify(payload);
+}
+export const theCodeGenSchema = {"type":"number","$id":"getCount_Response_200","$schema":"http://json-schema.org/draft-07/schema"};
+export function validate(context?: {data: any, ajvValidatorFunction?: ValidateFunction, ajvInstance?: Ajv, ajvOptions?: AjvOptions}): { valid: boolean; errors?: ErrorObject[]; } {
+  const {data, ajvValidatorFunction} = context ?? {};
+  // Intentionally parse JSON strings to support validation of marshalled output.
+  // Example: validate({data: marshal(obj)}) works because marshal returns JSON string.
+  // Note: String 'true' will be coerced to boolean true due to JSON.parse.
+  const parsedData = typeof data === 'string' ? JSON.parse(data) : data;
+  const validate = ajvValidatorFunction ?? createValidator(context)
+  return {
+    valid: validate(parsedData),
+    errors: validate.errors ?? undefined,
+  };
+}
+export function createValidator(context?: {ajvInstance?: Ajv, ajvOptions?: AjvOptions}): ValidateFunction {
+  const {ajvInstance} = {...context ?? {}, ajvInstance: new Ajv(context?.ajvOptions ?? {})};
+  addFormats(ajvInstance);
+  ajvInstance.addVocabulary(["xml", "example"])
+  const validate = ajvInstance.compile(theCodeGenSchema);
+  return validate;
+}
+
+
+export { GetCountResponse_200 };

--- a/test/runtime/typescript/src/openapi-primitive/payloads/GetEchoResponse_200.ts
+++ b/test/runtime/typescript/src/openapi-primitive/payloads/GetEchoResponse_200.ts
@@ -1,0 +1,33 @@
+import {Ajv, Options as AjvOptions, ErrorObject, ValidateFunction} from 'ajv';
+import {default as addFormats} from 'ajv-formats';
+type GetEchoResponse_200 = string;
+
+export function unmarshal(json: string): GetEchoResponse_200 {
+  return JSON.parse(json) as GetEchoResponse_200;
+}
+export function marshal(payload: GetEchoResponse_200): string {
+  return JSON.stringify(payload);
+}
+export const theCodeGenSchema = {"type":"string","$id":"getEcho_Response_200","$schema":"http://json-schema.org/draft-07/schema"};
+export function validate(context?: {data: any, ajvValidatorFunction?: ValidateFunction, ajvInstance?: Ajv, ajvOptions?: AjvOptions}): { valid: boolean; errors?: ErrorObject[]; } {
+  const {data, ajvValidatorFunction} = context ?? {};
+  // Intentionally parse JSON strings to support validation of marshalled output.
+  // Example: validate({data: marshal(obj)}) works because marshal returns JSON string.
+  // Note: String 'true' will be coerced to boolean true due to JSON.parse.
+  const parsedData = typeof data === 'string' ? JSON.parse(data) : data;
+  const validate = ajvValidatorFunction ?? createValidator(context)
+  return {
+    valid: validate(parsedData),
+    errors: validate.errors ?? undefined,
+  };
+}
+export function createValidator(context?: {ajvInstance?: Ajv, ajvOptions?: AjvOptions}): ValidateFunction {
+  const {ajvInstance} = {...context ?? {}, ajvInstance: new Ajv(context?.ajvOptions ?? {})};
+  addFormats(ajvInstance);
+  ajvInstance.addVocabulary(["xml", "example"])
+  const validate = ajvInstance.compile(theCodeGenSchema);
+  return validate;
+}
+
+
+export { GetEchoResponse_200 };

--- a/test/runtime/typescript/src/request-reply/channels/http_client.ts
+++ b/test/runtime/typescript/src/request-reply/channels/http_client.ts
@@ -1108,7 +1108,7 @@ async function postPingPostRequest(context: PostPingPostRequestContext): Promise
 
     // Parse response
     const rawData = await response.json();
-    const responseData = Pong.unmarshal(rawData);
+    const responseData = Pong.unmarshal(JSON.stringify(rawData));
 
     // Extract response metadata
     const responseHeaders = extractHeaders(response);
@@ -1230,7 +1230,7 @@ async function getPingGetRequest(context: GetPingGetRequestContext = {}): Promis
 
     // Parse response
     const rawData = await response.json();
-    const responseData = Pong.unmarshal(rawData);
+    const responseData = Pong.unmarshal(JSON.stringify(rawData));
 
     // Extract response metadata
     const responseHeaders = extractHeaders(response);
@@ -1353,7 +1353,7 @@ async function putPingPutRequest(context: PutPingPutRequestContext): Promise<Htt
 
     // Parse response
     const rawData = await response.json();
-    const responseData = Pong.unmarshal(rawData);
+    const responseData = Pong.unmarshal(JSON.stringify(rawData));
 
     // Extract response metadata
     const responseHeaders = extractHeaders(response);
@@ -1475,7 +1475,7 @@ async function deletePingDeleteRequest(context: DeletePingDeleteRequestContext =
 
     // Parse response
     const rawData = await response.json();
-    const responseData = Pong.unmarshal(rawData);
+    const responseData = Pong.unmarshal(JSON.stringify(rawData));
 
     // Extract response metadata
     const responseHeaders = extractHeaders(response);
@@ -1598,7 +1598,7 @@ async function patchPingPatchRequest(context: PatchPingPatchRequestContext): Pro
 
     // Parse response
     const rawData = await response.json();
-    const responseData = Pong.unmarshal(rawData);
+    const responseData = Pong.unmarshal(JSON.stringify(rawData));
 
     // Extract response metadata
     const responseHeaders = extractHeaders(response);
@@ -1720,7 +1720,7 @@ async function headPingHeadRequest(context: HeadPingHeadRequestContext = {}): Pr
 
     // Parse response
     const rawData = await response.json();
-    const responseData = Pong.unmarshal(rawData);
+    const responseData = Pong.unmarshal(JSON.stringify(rawData));
 
     // Extract response metadata
     const responseHeaders = extractHeaders(response);
@@ -1842,7 +1842,7 @@ async function optionsPingOptionsRequest(context: OptionsPingOptionsRequestConte
 
     // Parse response
     const rawData = await response.json();
-    const responseData = Pong.unmarshal(rawData);
+    const responseData = Pong.unmarshal(JSON.stringify(rawData));
 
     // Extract response metadata
     const responseHeaders = extractHeaders(response);
@@ -1964,7 +1964,7 @@ async function getMultiStatusResponse(context: GetMultiStatusResponseContext = {
 
     // Parse response
     const rawData = await response.json();
-    const responseData = MultiStatusResponseReplyPayloadModule.unmarshalByStatusCode(rawData, response.status);
+    const responseData = MultiStatusResponseReplyPayloadModule.unmarshalByStatusCode(JSON.stringify(rawData), response.status);
 
     // Extract response metadata
     const responseHeaders = extractHeaders(response);
@@ -2087,7 +2087,7 @@ async function getGetUserItem(context: GetGetUserItemContext): Promise<HttpClien
 
     // Parse response
     const rawData = await response.json();
-    const responseData = GetUserItemReplyPayloadModule.unmarshalByStatusCode(rawData, response.status);
+    const responseData = GetUserItemReplyPayloadModule.unmarshalByStatusCode(JSON.stringify(rawData), response.status);
 
     // Extract response metadata
     const responseHeaders = extractHeaders(response);
@@ -2211,7 +2211,7 @@ async function putUpdateUserItem(context: PutUpdateUserItemContext): Promise<Htt
 
     // Parse response
     const rawData = await response.json();
-    const responseData = UpdateUserItemReplyPayloadModule.unmarshalByStatusCode(rawData, response.status);
+    const responseData = UpdateUserItemReplyPayloadModule.unmarshalByStatusCode(JSON.stringify(rawData), response.status);
 
     // Extract response metadata
     const responseHeaders = extractHeaders(response);

--- a/test/runtime/typescript/test/channels/request_reply/http_client/primitive-response.spec.ts
+++ b/test/runtime/typescript/test/channels/request_reply/http_client/primitive-response.spec.ts
@@ -1,0 +1,48 @@
+/* eslint-disable no-console */
+/**
+ * Regression test for primitive-typed response payloads.
+ *
+ * Payloads whose schema is a primitive (e.g. `type: string`/`number`) generate
+ * `unmarshal(json: string)` which JSON.parses its argument. The HTTP client must
+ * therefore hand unmarshal the raw JSON text, not the already-parsed value from
+ * response.json(). Before the fix this threw at runtime (JSON.parse on an
+ * already-parsed primitive). See fix/openapi-http-client-primitive-response.
+ */
+import { createTestServer, runWithServer } from './test-utils';
+import { getEcho, getCount } from '../../../../src/openapi-primitive/channels/http_client';
+
+jest.setTimeout(15000);
+
+describe('HTTP Client - primitive response payloads', () => {
+  it('unmarshals a plain string body', async () => {
+    const { app, router, port } = createTestServer();
+
+    router.get('/echo', (_req, res) => {
+      res.setHeader('Content-Type', 'application/json');
+      res.end(JSON.stringify('hello world'));
+    });
+
+    return runWithServer(app, port, async (_server, actualPort) => {
+      const response = await getEcho({ server: `http://localhost:${actualPort}` });
+
+      expect(response.status).toBe(200);
+      expect(response.data).toBe('hello world');
+    });
+  });
+
+  it('unmarshals a plain number body', async () => {
+    const { app, router, port } = createTestServer();
+
+    router.get('/count', (_req, res) => {
+      res.setHeader('Content-Type', 'application/json');
+      res.end(JSON.stringify(42));
+    });
+
+    return runWithServer(app, port, async (_server, actualPort) => {
+      const response = await getCount({ server: `http://localhost:${actualPort}` });
+
+      expect(response.status).toBe(200);
+      expect(response.data).toBe(42);
+    });
+  });
+});


### PR DESCRIPTION
## Why

When an OpenAPI operation's response schema is a **primitive** (e.g. `type: string` or `type: number`), the payload generator emits `unmarshal(json: string)` which `JSON.parse`s its argument. But the generated HTTP client handed `unmarshal` the **already-parsed** value from `response.json()`:

```ts
const rawData = await response.json();          // parsed value
const responseData = Module.unmarshal(rawData); // primitive unmarshal expects raw text
```

For primitive responses this both:
- **failed to type-check** — `Record<any, any>` is not assignable to `string` (`TS2345`), and
- **threw at runtime** — `JSON.parse` on an already-parsed value (`SyntaxError: Unexpected token 'h', "hello world" is not valid JSON`).

Object/array payloads happened to work because their `unmarshal` accepts `string | object` / `string | any[]`.

## What

Hand `unmarshal` the **raw JSON text** via `JSON.stringify(rawData)`:

```ts
const rawData = await response.json();
const responseData = Module.unmarshal(JSON.stringify(rawData));
```

Every unmarshal variant accepts a string — object (`string | object`), array (`string | any[]`), primitive (`string`), and `unmarshalByStatusCode` (`any`) — so this is uniform across all reply payload kinds. `rawData` stays the parsed object for the response wrapper's `rawData` field.

## Tests

- **New `openapi-primitive` runtime fixture** (`test/runtime/openapi-primitive.json` + `codegen-openapi-primitive.mjs`, wired into the runtime `generate` script) with operations returning a plain `string` and a plain `number`.
- **`primitive-response.spec.ts`** drives the generated client against a server returning primitive bodies and asserts they unmarshal correctly. This **fails before the fix** (`SyntaxError: ... is not valid JSON`) and passes after.
- **`channels.spec`** asserts the generated client unmarshals from `JSON.stringify(rawData)` (and never `unmarshal(rawData)`), locking in the generation change.
- Full runtime HTTP suite: **16 suites / 128 tests pass**; full unit suite: **50 suites / 630 tests pass**.

Independent of #387 (auth narrowing) — both touch `client.ts` but in different regions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
