### PR TITLE
chore(release): v0.72.5

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -85,3 +85,4 @@ Connect AI assistants like Claude Code, Cursor, and Windsurf to The Codegen Proj
 
 
 
+

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -203,3 +203,4 @@ Prefix that follows specification is not enough though. Remember that the title 
 
 
 
+

--- a/docs/migrations/v0.md
+++ b/docs/migrations/v0.md
@@ -173,3 +173,4 @@ interface GeneratedFile {
 
 
 
+

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -9,7 +9,7 @@ $ npm install -g @alagoni97/cli
 $ codegen COMMAND
 running command...
 $ codegen (--version)
-@alagoni97/cli/0.72.4 linux-x64 node-v22.23.1
+@alagoni97/cli/0.72.5 linux-x64 node-v22.23.1
 $ codegen --help [COMMAND]
 USAGE
   $ codegen COMMAND
@@ -80,7 +80,7 @@ FLAGS
       --silent    Suppress all output except fatal errors
 ```
 
-_See code: [src/commands/base.ts](https://github.com/the-codegen-project/cli/blob/v0.72.4/src/commands/base.ts)_
+_See code: [src/commands/base.ts](https://github.com/the-codegen-project/cli/blob/v0.72.5/src/commands/base.ts)_
 
 ## `codegen generate [FILE]`
 
@@ -111,7 +111,7 @@ DESCRIPTION
   configuration.
 ```
 
-_See code: [src/commands/generate.ts](https://github.com/the-codegen-project/cli/blob/v0.72.4/src/commands/generate.ts)_
+_See code: [src/commands/generate.ts](https://github.com/the-codegen-project/cli/blob/v0.72.5/src/commands/generate.ts)_
 
 ## `codegen help [COMMAND]`
 
@@ -178,7 +178,7 @@ DESCRIPTION
   Initialize The Codegen Project in your project
 ```
 
-_See code: [src/commands/init.ts](https://github.com/the-codegen-project/cli/blob/v0.72.4/src/commands/init.ts)_
+_See code: [src/commands/init.ts](https://github.com/the-codegen-project/cli/blob/v0.72.5/src/commands/init.ts)_
 
 ## `codegen telemetry ACTION`
 
@@ -211,7 +211,7 @@ EXAMPLES
   $ codegen telemetry disable
 ```
 
-_See code: [src/commands/telemetry.ts](https://github.com/the-codegen-project/cli/blob/v0.72.4/src/commands/telemetry.ts)_
+_See code: [src/commands/telemetry.ts](https://github.com/the-codegen-project/cli/blob/v0.72.5/src/commands/telemetry.ts)_
 
 ## `codegen version`
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@alagoni97/cli",
-  "version": "0.72.4",
+  "version": "0.72.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@alagoni97/cli",
-      "version": "0.72.4",
+      "version": "0.72.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@apidevtools/json-schema-ref-parser": "^14.2.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@alagoni97/cli",
   "description": "CLI to work with code generation in any environment",
-  "version": "0.72.4",
+  "version": "0.72.5",
   "bin": {
     "codegen": "./bin/run.mjs"
   },


### PR DESCRIPTION
Version bump in package.json for release [v0.72.5](https://github.com/the-codegen-project/cli/releases/tag/v0.72.5)