### PR TITLE
fix: forward path-parameter model name for OpenAPI http_client operations

### DIFF
--- a/src/codegen/generators/typescript/channels/openapi.ts
+++ b/src/codegen/generators/typescript/channels/openapi.ts
@@ -124,7 +124,7 @@ export async function generateTypeScriptChannelsForOpenAPI(
       functionName: r.functionName,
       messageType: r.messageType ?? '',
       replyType: r.replyType,
-      parameterType: undefined
+      parameterType: r.parameterType
     }))
   );
 

--- a/src/codegen/generators/typescript/channels/protocols/http/client.ts
+++ b/src/codegen/generators/typescript/channels/protocols/http/client.ts
@@ -81,7 +81,8 @@ ${functionCode}`;
     code,
     functionName,
     dependencies: [],
-    functionType: ChannelFunctionTypes.HTTP_CLIENT
+    functionType: ChannelFunctionTypes.HTTP_CLIENT,
+    parameterType: channelParameters?.name
   };
 }
 

--- a/src/codegen/types.ts
+++ b/src/codegen/types.ts
@@ -206,6 +206,10 @@ export interface HttpRenderType {
   functionType: ChannelFunctionTypes;
   messageType?: string;
   replyType: string;
+  // Name of the generated path-parameter model, when the operation declares
+  // path parameters. Consumers (e.g. README generation) rely on this to know an
+  // operation requires a `parameters` argument.
+  parameterType?: string;
 }
 
 const SCHEMA_DESCRIPTION =

--- a/test/codegen/generators/typescript/channels.spec.ts
+++ b/test/codegen/generators/typescript/channels.spec.ts
@@ -629,6 +629,22 @@ describe('channels', () => {
         const httpProtocolCode = generatedChannels.protocolFiles['http_client'];
         expect(httpProtocolCode).toContain('unmarshal(JSON.stringify(rawData))');
         expect(httpProtocolCode).not.toMatch(/unmarshal\(rawData\)/);
+
+        // Operations with path parameters must expose their parameter model name via
+        // parameterType so downstream consumers (e.g. README generation) know the
+        // operation requires a `parameters` argument. Operations without parameters
+        // must leave it undefined. Regression guard for the previously hardcoded
+        // `parameterType: undefined`.
+        const httpFunctions = generatedChannels.renderedFunctions['http_client'];
+        const withParameters = httpFunctions.find(
+          (fn) => fn.functionName === 'findPetsByStatusAndCategory'
+        );
+        expect(withParameters?.parameterType).toBe('FindPetsByStatusAndCategoryParameters');
+        const withoutParameters = httpFunctions.find(
+          (fn) => fn.functionName !== 'findPetsByStatusAndCategory'
+        );
+        expect(withoutParameters).toBeDefined();
+        expect(withoutParameters?.parameterType).toBeUndefined();
       });
 
       it('should skip generation when http_client is not in protocols', async () => {


### PR DESCRIPTION
## Problem

For OpenAPI inputs, the `http_client` channels generator pushed every operation into `renderedFunctions` with a hardcoded `parameterType: undefined` (`src/codegen/generators/typescript/channels/openapi.ts`). It forwarded `messageType`/`replyType` but dropped the path-parameter information entirely.

Downstream consumers rely on `parameterType` to know whether an operation requires a `parameters` argument. In particular, README generation (in the `platform-and-services` library) uses it to decide whether to show a `parameters` line in the usage example and to pick a genuinely argument-free "primary" example.

Because it was always `undefined`, the generated README could:

- advertise a call that **omits the required `parameters`** for path-parameter operations — e.g. `getV2ConnectReferenceId` for `GET /v2/connect/{referenceId}` — yielding a snippet that does not type-check (`Property 'parameters' is missing in type … but required in type 'GetV2ConnectReferenceIdContext'`); and
- select such an operation as the "simple" primary example, since every operation looked parameter-free.

The functions themselves were always exported correctly — this is purely about the metadata that drives documentation/examples.

## Fix

- Add `parameterType?: string` to `HttpRenderType` and populate it in `renderHttpFetchClient` with the parameter model name (`channelParameters?.name`) when the operation declares path parameters.
- Forward `r.parameterType` (instead of `undefined`) through `renderedFunctions` in the OpenAPI channels generator.

Operations without path parameters continue to report `undefined`.

## Verification

- `npm run typecheck` — clean.
- `npm test -- --testPathPattern=channels.spec` — 13 passed, snapshots unchanged.
- Added a regression assertion to the existing OpenAPI `http_client` test: a path-parameter operation (`findPetsByStatusAndCategory`) now exposes `parameterType: 'FindPetsByStatusAndCategoryParameters'`, while a parameter-free operation reports `undefined`.
- End-to-end against a real OpenAPI spec: the generated README now selects an operation with no required path parameters as the primary example and labels required `payload`/`parameters` correctly, instead of silently dropping a required `parameters` argument.

🤖 Generated with [Claude Code](https://claude.com/claude-code)