### PR TITLE
fix: revert temporary publisher back to @the-codegen-project/cli

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@alagoni97/cli",
+  "name": "@the-codegen-project/cli",
   "version": "0.72.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@alagoni97/cli",
+      "name": "@the-codegen-project/cli",
       "version": "0.72.9",
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@alagoni97/cli",
+  "name": "@the-codegen-project/cli",
   "description": "CLI to work with code generation in any environment",
   "version": "0.72.9",
   "bin": {

--- a/test/blackbox/configs/typescript/channels-empty.config.js
+++ b/test/blackbox/configs/typescript/channels-empty.config.js
@@ -1,4 +1,4 @@
-/** @type {import("@alagoni97/cli").TheCodegenConfiguration} TheCodegenConfiguration **/
+/** @type {import("@the-codegen-project/cli").TheCodegenConfiguration} TheCodegenConfiguration **/
 export default {
 	inputType: 'asyncapi',
 	inputPath: 'asyncapi.json',

--- a/test/blackbox/configs/typescript/channels-websocket.config.js
+++ b/test/blackbox/configs/typescript/channels-websocket.config.js
@@ -1,4 +1,4 @@
-/** @type {import("@alagoni97/cli").TheCodegenConfiguration} TheCodegenConfiguration **/
+/** @type {import("@the-codegen-project/cli").TheCodegenConfiguration} TheCodegenConfiguration **/
 export default {
 	inputType: 'asyncapi',
 	inputPath: 'asyncapi.json',

--- a/test/blackbox/configs/typescript/channels.config.js
+++ b/test/blackbox/configs/typescript/channels.config.js
@@ -1,4 +1,4 @@
-/** @type {import("@alagoni97/cli").TheCodegenConfiguration} TheCodegenConfiguration **/
+/** @type {import("@the-codegen-project/cli").TheCodegenConfiguration} TheCodegenConfiguration **/
 export default {
 	inputType: 'asyncapi',
 	inputPath: 'asyncapi.json',

--- a/test/blackbox/configs/typescript/client-empty.config.js
+++ b/test/blackbox/configs/typescript/client-empty.config.js
@@ -1,4 +1,4 @@
-/** @type {import("@alagoni97/cli").TheCodegenConfiguration} TheCodegenConfiguration **/
+/** @type {import("@the-codegen-project/cli").TheCodegenConfiguration} TheCodegenConfiguration **/
 export default {
 	inputType: 'asyncapi',
 	inputPath: 'asyncapi.json',

--- a/test/blackbox/configs/typescript/client.config.js
+++ b/test/blackbox/configs/typescript/client.config.js
@@ -1,4 +1,4 @@
-/** @type {import("@alagoni97/cli").TheCodegenConfiguration} TheCodegenConfiguration **/
+/** @type {import("@the-codegen-project/cli").TheCodegenConfiguration} TheCodegenConfiguration **/
 export default {
 	inputType: 'asyncapi',
 	inputPath: 'asyncapi.json',

--- a/test/blackbox/configs/typescript/headers.config.js
+++ b/test/blackbox/configs/typescript/headers.config.js
@@ -1,4 +1,4 @@
-/** @type {import("@alagoni97/cli").TheCodegenConfiguration} TheCodegenConfiguration **/
+/** @type {import("@the-codegen-project/cli").TheCodegenConfiguration} TheCodegenConfiguration **/
 export default {
 	inputType: 'asyncapi',
 	inputPath: 'asyncapi.json',

--- a/test/blackbox/configs/typescript/modelina-config-preset.js
+++ b/test/blackbox/configs/typescript/modelina-config-preset.js
@@ -1,6 +1,6 @@
-import { modelina } from '@alagoni97/cli';
+import { modelina } from '@the-codegen-project/cli';
 const { TS_COMMON_PRESET } = modelina;
-/** @type {import("@alagoni97/cli").TheCodegenConfiguration} TheCodegenConfiguration **/
+/** @type {import("@the-codegen-project/cli").TheCodegenConfiguration} TheCodegenConfiguration **/
 export default {
 	inputType: 'asyncapi',
 	inputPath: 'asyncapi.json',

--- a/test/blackbox/configs/typescript/modelina-config.js
+++ b/test/blackbox/configs/typescript/modelina-config.js
@@ -1,4 +1,4 @@
-/** @type {import("@alagoni97/cli").TheCodegenConfiguration} TheCodegenConfiguration **/
+/** @type {import("@the-codegen-project/cli").TheCodegenConfiguration} TheCodegenConfiguration **/
 export default {
 	inputType: 'asyncapi',
 	inputPath: 'asyncapi.json',

--- a/test/blackbox/configs/typescript/parameters.config.js
+++ b/test/blackbox/configs/typescript/parameters.config.js
@@ -1,4 +1,4 @@
-/** @type {import("@alagoni97/cli").TheCodegenConfiguration} TheCodegenConfiguration **/
+/** @type {import("@the-codegen-project/cli").TheCodegenConfiguration} TheCodegenConfiguration **/
 export default {
 	inputType: 'asyncapi',
 	inputPath: 'asyncapi.json',

--- a/test/blackbox/configs/typescript/payload.config.js
+++ b/test/blackbox/configs/typescript/payload.config.js
@@ -1,4 +1,4 @@
-/** @type {import("@alagoni97/cli").TheCodegenConfiguration} TheCodegenConfiguration **/
+/** @type {import("@the-codegen-project/cli").TheCodegenConfiguration} TheCodegenConfiguration **/
 export default {
 	inputType: 'asyncapi',
 	inputPath: 'asyncapi.json',

--- a/test/configs/config-all.js
+++ b/test/configs/config-all.js
@@ -1,5 +1,5 @@
 /* eslint-disable sonarjs/no-duplicate-string */
-/** @type {import("@alagoni97/cli").TheCodegenConfiguration} TheCodegenConfiguration **/
+/** @type {import("@the-codegen-project/cli").TheCodegenConfiguration} TheCodegenConfiguration **/
 export default {
 	inputType: 'asyncapi',
 	inputPath: 'asyncapi.json',

--- a/test/configs/config-custom.js
+++ b/test/configs/config-custom.js
@@ -1,4 +1,4 @@
-/** @type {import("@alagoni97/cli").TheCodegenConfiguration} TheCodegenConfiguration **/
+/** @type {import("@the-codegen-project/cli").TheCodegenConfiguration} TheCodegenConfiguration **/
 export default {
 	inputType: 'asyncapi',
 	inputPath: "asyncapi.json",

--- a/test/configs/config-implicit.js
+++ b/test/configs/config-implicit.js
@@ -1,5 +1,5 @@
 /* eslint-disable sonarjs/no-duplicate-string */
-/** @type {import("@alagoni97/cli").TheCodegenConfiguration} TheCodegenConfiguration **/
+/** @type {import("@the-codegen-project/cli").TheCodegenConfiguration} TheCodegenConfiguration **/
 export default {
 	inputType: 'asyncapi',
 	inputPath: 'asyncapi-request.yaml',

--- a/test/configs/config.js
+++ b/test/configs/config.js
@@ -1,4 +1,4 @@
-/** @type {import("@alagoni97/cli").TheCodegenConfiguration} TheCodegenConfiguration **/
+/** @type {import("@the-codegen-project/cli").TheCodegenConfiguration} TheCodegenConfiguration **/
 export default {
 	inputType: 'asyncapi',
 	inputPath: 'asyncapi.yaml',

--- a/test/configs/config.ts
+++ b/test/configs/config.ts
@@ -1,4 +1,4 @@
-import {TheCodegenConfiguration} from '@alagoni97/cli';
+import {TheCodegenConfiguration} from '@the-codegen-project/cli';
 
 const config: TheCodegenConfiguration = {
 	inputType: 'asyncapi',


### PR DESCRIPTION
Reverts #379 ("fix: change temp. publisher") now that the npm publish token for `@the-codegen-project/cli` is available again.

## What changed
- Restores the package name from the temporary `@alagoni97/cli` back to `@the-codegen-project/cli` in `package.json`, `package-lock.json`, and all test config files.

## Note on resolution
The lockfile conflicted because #379 was made at version `0.72.0`, while `main` is now at `0.72.9`. The revert was resolved to **keep the current version `0.72.9`** while restoring the original package name — the version is not rolled back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)