### PR TITLE
fix(http): type context parameters and headers with concrete generated models

### DIFF
--- a/src/codegen/generators/typescript/channels/protocols/http/client.ts
+++ b/src/codegen/generators/typescript/channels/protocols/http/client.ts
@@ -17,6 +17,7 @@ export function renderHttpFetchClient({
   replyMessageType,
   replyMessageModule,
   channelParameters,
+  channelHeaders,
   method,
   servers = [],
   subName = pascalCase(requestTopic),
@@ -43,7 +44,8 @@ export function renderHttpFetchClient({
   const contextInterface = generateContextInterface(
     contextInterfaceName,
     messageType,
-    hasParameters,
+    channelParameters?.type,
+    channelHeaders?.type,
     method
   );
 
@@ -92,7 +94,8 @@ ${functionCode}`;
 function generateContextInterface(
   interfaceName: string,
   messageType: string | undefined,
-  hasParameters: boolean,
+  parametersType: string | undefined,
+  headersType: string | undefined,
   method: string
 ): string {
   const fields: string[] = [];
@@ -102,16 +105,19 @@ function generateContextInterface(
     fields.push(`  payload: ${messageType};`);
   }
 
-  // Add parameters field if operation has path parameters
-  if (hasParameters) {
-    fields.push(
-      `  parameters: { getChannelWithParameters: (path: string) => string };`
-    );
+  // Reference the concrete generated parameter class so consumers get typed
+  // query/path parameters. It still exposes getChannelWithParameters, so the
+  // buildUrlWithParameters call in the function body keeps working.
+  if (parametersType) {
+    fields.push(`  parameters: ${parametersType};`);
   }
 
-  // Add requestHeaders field (optional) for operations that support typed headers
-  // This is always optional since headers can also be passed via additionalHeaders
-  fields.push(`  requestHeaders?: { marshal: () => string };`);
+  // Reference the concrete generated headers model when available; fall back to
+  // the structural marshal contract otherwise. Always optional since headers can
+  // also be passed via additionalHeaders.
+  fields.push(
+    `  requestHeaders?: ${headersType ?? '{ marshal: () => string }'};`
+  );
 
   const fieldsStr = fields.length > 0 ? `\n${fields.join('\n')}\n` : '';
 

--- a/src/codegen/generators/typescript/channels/protocols/http/index.ts
+++ b/src/codegen/generators/typescript/channels/protocols/http/index.ts
@@ -84,7 +84,7 @@ function generateForOperations(
   parameters: ConstrainedObjectModel | undefined
 ): HttpRenderType[] {
   const renders: HttpRenderType[] = [];
-  const {generator, payloads} = context;
+  const {generator, payloads, headers} = context;
   const functionTypeMapping = generator.functionTypeMapping?.[channel.id()];
 
   for (const operation of channel.operations().all()) {
@@ -138,6 +138,7 @@ function generateForOperations(
             method: httpMethod.toUpperCase(),
             channelParameters:
               parameters !== undefined ? parameters : undefined,
+            channelHeaders: headers,
             includesStatusCodes: replyIncludesStatusCodes,
             description,
             deprecated

--- a/src/codegen/generators/typescript/channels/types.ts
+++ b/src/codegen/generators/typescript/channels/types.ts
@@ -284,6 +284,7 @@ export interface RenderHttpParameters {
   replyMessageType: string;
   replyMessageModule: string | undefined;
   channelParameters: ConstrainedObjectModel | undefined;
+  channelHeaders?: ConstrainedObjectModel | undefined;
   subName?: string;
   functionName?: string;
   method: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'OPTIONS' | 'HEAD';

--- a/test/codegen/generators/typescript/__snapshots__/channels.spec.ts.snap
+++ b/test/codegen/generators/typescript/__snapshots__/channels.spec.ts.snap
@@ -1245,7 +1245,7 @@ async function updatePet(context: UpdatePetContext): Promise<HttpClientResponse<
 }
 
 export interface FindPetsByStatusAndCategoryContext extends HttpClientContext {
-  parameters: { getChannelWithParameters: (path: string) => string };
+  parameters: Parameter;
   requestHeaders?: { marshal: () => string };
 }
 

--- a/test/runtime/typescript/src/request-reply/channels/http_client.ts
+++ b/test/runtime/typescript/src/request-reply/channels/http_client.ts
@@ -2003,8 +2003,8 @@ async function getMultiStatusResponse(context: GetMultiStatusResponseContext = {
 }
 
 export interface GetGetUserItemContext extends HttpClientContext {
-  parameters: { getChannelWithParameters: (path: string) => string };
-  requestHeaders?: { marshal: () => string };
+  parameters: UserItemsParameters;
+  requestHeaders?: ItemRequestHeaders;
 }
 
 /**
@@ -2127,8 +2127,8 @@ async function getGetUserItem(context: GetGetUserItemContext): Promise<HttpClien
 
 export interface PutUpdateUserItemContext extends HttpClientContext {
   payload: ItemRequest;
-  parameters: { getChannelWithParameters: (path: string) => string };
-  requestHeaders?: { marshal: () => string };
+  parameters: UserItemsParameters;
+  requestHeaders?: ItemRequestHeaders;
 }
 
 /**


### PR DESCRIPTION
## Problem

When generating a TypeScript HTTP fetch client, the generated context interface discarded the fully-typed parameter class and headers model that are **already generated**. Instead of the concrete types, it emitted structural stubs:

```ts
export interface GetV2TransactionsContext extends HttpClientContext {
  parameters: { getChannelWithParameters: (path: string) => string };
  requestHeaders?: { marshal: () => string };
}
```

So a consumer calling `getV2Transactions(context)` got **no type support** on `context.parameters` (the actual query/path params like `skip`, `take`, `search`, `referenceId`) or `context.requestHeaders`.

## Fix

`generateContextInterface` (in `http/client.ts`) only received a `hasParameters: boolean` and never saw the concrete class names — even though they were already in hand (`channelParameters.type`). The headers model wasn't threaded into the renderer at all.

- Thread `channelParameters.type` / `channelHeaders.type` into the context interface, mirroring the existing **EventSource** protocol.
- Plumb the headers model through `http/index.ts` → `renderHttpFetchClient` (added `channelHeaders` to `RenderHttpParameters`).

Result:

```ts
export interface GetGetUserItemContext extends HttpClientContext {
  parameters: UserItemsParameters;
  requestHeaders?: ItemRequestHeaders;
}
```

The concrete parameter class still exposes `getChannelWithParameters`, so `buildUrlWithParameters(...)` in the function body is unaffected. Operations without a typed headers model keep the structural `{ marshal: () => string }` fallback.

## Verification

- `npm run typecheck` passes.
- Regenerated the committed runtime output (`test/runtime/typescript/src/request-reply/channels/http_client.ts`) — context interfaces now reference `UserItemsParameters` / `ItemRequestHeaders`, matching what the `parameters-headers.spec.ts` runtime spec already imports and constructs.
- Sanity-checked against the `openapi-http-client` example: `parameters` now resolves to the concrete generated params class.

> Note: `npm run prepare:pr` could not be run to completion locally because ESLint 8's extensionless `.eslintrc` loader fails under Node 25 (pre-existing, reproduces on a clean checkout, unrelated to this diff). Please run the full quality gate in CI / on a Node 22 environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)